### PR TITLE
Get connect-graphene and connect-graphene-force to work

### DIFF
--- a/src/allowed_args.cpp
+++ b/src/allowed_args.cpp
@@ -533,6 +533,10 @@ static void addDebuggingOptions(AllowedArgs &allowedArgs, HelpMessageMode mode)
         .addDebugArg("printpriority", optionalBool,
             strprintf("Log transaction priority and fee per kB when mining blocks (default: %u)",
                          DEFAULT_PRINTPRIORITY))
+        .addDebugArg("connect-thinblock-force", optionalBool,
+            strprintf("Force download of thinblocks from connect-thinblock peers (default: %u)", false))
+        .addDebugArg("connect-graphene-force", optionalBool,
+            strprintf("Force download of graphene blocks from connect-graphene peers (default: %u)", false))
 #ifdef ENABLE_WALLET
         .addDebugArg("privdb", optionalBool,
             strprintf("Sets the DB_PRIVATE flag in the wallet db environment (default: %u)", DEFAULT_WALLET_PRIVDB))

--- a/src/allowed_args.cpp
+++ b/src/allowed_args.cpp
@@ -297,7 +297,7 @@ static void addConnectionOptions(AllowedArgs &allowedArgs)
             _("Connect to a thinblock node(s). Blocks will only be downloaded from a thinblock peer.  If no "
               "connections "
               "are possible then regular blocks will then be downloaded form any other connected peers"))
-        .addArg("connect-grapheneblock=<ip:port>", requiredStr,
+        .addArg("connect-graphene=<ip:port>", requiredStr,
             _("Connect to graphene node(s). Blocks will only be downloaded from a graphene capable peer.  If no "
               "connections are possible then regular blocks will then be downloaded form any other connected peers"))
         .addArg("discover", optionalBool,

--- a/src/graphene.cpp
+++ b/src/graphene.cpp
@@ -1309,10 +1309,8 @@ bool CanGrapheneBlockBeDownloaded(CNode *pto)
         // When -connect-graphene-force is true we will only download graphene blocks from a peer or peers that
         // are using -connect-graphene=<ip>.  This is an undocumented setting used for setting up performance testing
         // of graphene blocks, such as, going over the GFC and needing to have graphene blocks always come from the same
-        // peer or
-        // group of peers.  Also, this is a one way street.  Graphene blocks will flow ONLY from the remote peer to the
-        // peer
-        // that has invoked -connect-graphene.
+        // peer or group of peers.  Also, this is a one way street.  Graphene blocks will flow ONLY from the remote peer
+        // to the peer that has invoked -connect-graphene.
 
         // Check if this node is also a connect-graphene node
         for (const std::string &strAddrNode : mapMultiArgs["-connect-graphene"])

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -20,6 +20,7 @@
 #include "consensus/consensus.h"
 #include "crypto/common.h"
 #include "dosman.h"
+#include "graphene.h"
 #include "hash.h"
 #include "iblt.h"
 #include "primitives/transaction.h"
@@ -1731,10 +1732,8 @@ void static ProcessOneShot()
 
 void ThreadOpenConnections()
 {
-    // Connect to specific addresses
-    if ((mapArgs.count("-connect") && mapMultiArgs["-connect"].size() > 0) ||
-        // BUIP010 Xtreme Thinblocks
-        (mapArgs.count("-connect-thinblock") && mapMultiArgs["-connect-thinblock"].size() > 0))
+    // Connect to all "connect" peers
+    if (mapArgs.count("-connect") && mapMultiArgs["-connect"].size() > 0)
     {
         for (int64_t nLoop = 0;; nLoop++)
         {
@@ -1752,15 +1751,17 @@ void ThreadOpenConnections()
                 }
             }
             MilliSleep(500);
-
-            // BUIP010 Xtreme Thinblocks: begin section
-            ConnectToThinBlockNodes();
-            // BUIP010 Xtreme Thinblocks: end section
         }
-
-        // NOTE: If we are in this block, then no seeding should occur as both "-connect" and
-        //      "-connect-thinblock" are intended as "only make outbound connections to the configured nodes".
     }
+
+    // Connect to all "connect-thinblock" peers
+    ConnectToThinBlockNodes();
+
+    // Connect to all "connect-graphene" peers
+    ConnectToGrapheneBlockNodes();
+
+    // NOTE: If we are in the block above, then no seeding should occur as "-connect", "-connect-thinblock"
+    // and "connect-graphene" are intended as "only make outbound connections to the configured nodes".
 
     // Initiate network connections
     int64_t nStart = GetTime();

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -61,9 +61,8 @@ static const char *ppszTypeName[] = {
     "ERROR", // Should never occur
     NetMsgType::TX, NetMsgType::BLOCK,
     "filtered block", // Should never occur
-    // BUIP010 Xtreme Thinblocks - begin section
     NetMsgType::THINBLOCK, NetMsgType::XTHINBLOCK,
-    // BUIP010 Xtreme Thinblocks - end section
+    NetMsgType::GRAPHENEBLOCK,
 };
 
 /** All known message types. Keep this in the same order as the list of
@@ -75,10 +74,9 @@ const static std::string allNetMessageTypes[] = {
     NetMsgType::BLOCK, NetMsgType::GETADDR, NetMsgType::MEMPOOL, NetMsgType::PING, NetMsgType::PONG,
     NetMsgType::NOTFOUND, NetMsgType::FILTERLOAD, NetMsgType::FILTERADD, NetMsgType::FILTERCLEAR,
     NetMsgType::FILTERSIZEXTHIN, NetMsgType::REJECT, NetMsgType::SENDHEADERS,
-    // BUIP010 Xtreme Thinbocks - begin section
     NetMsgType::THINBLOCK, NetMsgType::XTHINBLOCK, NetMsgType::XBLOCKTX, NetMsgType::GET_XBLOCKTX,
     NetMsgType::GET_XTHIN,
-    // BUIP010 Xtreme Thinbocks - end section
+    NetMsgType::GRAPHENEBLOCK, NetMsgType::GRAPHENETX, NetMsgType::GET_GRAPHENETX, NetMsgType::GET_GRAPHENE,
     NetMsgType::XPEDITEDREQUEST, NetMsgType::XPEDITEDBLK, NetMsgType::XPEDITEDTxn, NetMsgType::BUVERSION,
     NetMsgType::BUVERACK,
 };

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -160,19 +160,19 @@ extern const char *GET_XBLOCKTX;
  */
 extern const char *GET_XTHIN;
 /**
- * BUIPXXX Graphene: The grapheneblock message transmits a single serialized graphene block.
+ * The grapheneblock message transmits a single serialized graphene block.
  */
 extern const char *GRAPHENEBLOCK;
 /**
- * BUIPXXX Graphene: The graphenetx message transmits a single serialized grblktx.
+ * The graphenetx message transmits a single serialized grblktx.
  */
 extern const char *GRAPHENETX;
 /**
- * BUIPXXX Graphene: The get_graphenetx message transmits a single serialized get_grblktx.
+ * The get_graphenetx message transmits a single serialized get_grblktx.
  */
 extern const char *GET_GRAPHENETX;
 /**
- * BUIPXXX Graphene: The get_graphene message transmits a single serialized get_grblk.
+ * The get_graphene message transmits a single serialized get_grblk.
  */
 extern const char *GET_GRAPHENE;
 

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -995,7 +995,7 @@ QString formatServicesStr(quint64 mask)
                 break;
             case NODE_GRAPHENE:
                 strList.append("GRAPH");
-                break;               
+                break;
             default:
                 strList.append(QString("%1[%2]").arg("UNKNOWN").arg(check));
             }


### PR DESCRIPTION
ConnectToGrapheneBlockNodes() was missing from the startup where initial connections are made and also the hidden config option for connect-graphene-force was missing as was the old connect-thinblock-force.