### PR TITLE
A variety of nits

### DIFF
--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -82,9 +82,10 @@ proxyType nameProxy;
 CCriticalSection cs_proxyInfos;
 
 
-set<uint256> setPreVerifiedTxHash;
-set<uint256> setUnVerifiedOrphanTxHash;
 CCriticalSection cs_xval;
+set<uint256> setPreVerifiedTxHash GUARDED_BY(cs_xval);
+set<uint256> setUnVerifiedOrphanTxHash GUARDED_BY(cs_xval);
+
 CCriticalSection cs_vNodes;
 CCriticalSection cs_mapLocalHost;
 map<CNetAddr, LocalServiceInfo> mapLocalHost;

--- a/src/graphene.cpp
+++ b/src/graphene.cpp
@@ -1123,7 +1123,7 @@ std::string CGrapheneBlockData::MempoolLimiterBytesSavedToString()
 // block inventory is from a non GRAPHENE node then we will continue to wait for block announcements until either we
 // get one from an GRAPHENE capable node or the timer is exceeded.  If the timer is exceeded before receiving an
 // announcement from an GRAPHENE node then we just download a full block instead of a graphene block.
-bool CGrapheneBlockData::CheckGrapheneBlockTimer(uint256 hash)
+bool CGrapheneBlockData::CheckGrapheneBlockTimer(const uint256 &hash)
 {
     LOCK(cs_mapGrapheneBlockTimer);
     if (!mapGrapheneBlockTimer.count(hash))
@@ -1148,7 +1148,7 @@ bool CGrapheneBlockData::CheckGrapheneBlockTimer(uint256 hash)
 }
 
 // The timer is cleared as soon as we request a block or graphene block.
-void CGrapheneBlockData::ClearGrapheneBlockTimer(uint256 hash)
+void CGrapheneBlockData::ClearGrapheneBlockTimer(const uint256 &hash)
 {
     LOCK(cs_mapGrapheneBlockTimer);
     if (mapGrapheneBlockTimer.count(hash))
@@ -1177,7 +1177,7 @@ void CGrapheneBlockData::ClearGrapheneBlockData(CNode *pnode)
         graphenedata.GetGrapheneBlockBytes());
 }
 
-void CGrapheneBlockData::ClearGrapheneBlockData(CNode *pnode, uint256 hash)
+void CGrapheneBlockData::ClearGrapheneBlockData(CNode *pnode, const uint256 &hash)
 {
     // We must make sure to clear the graphene block data first before clearing the graphene block in flight.
     ClearGrapheneBlockData(pnode);
@@ -1379,13 +1379,13 @@ bool ClearLargestGrapheneBlockAndDisconnect(CNode *pfrom)
     return false;
 }
 
-void ClearGrapheneBlockInFlight(CNode *pfrom, uint256 hash)
+void ClearGrapheneBlockInFlight(CNode *pfrom, const uint256 &hash)
 {
     LOCK(pfrom->cs_mapgrapheneblocksinflight);
     pfrom->mapGrapheneBlocksInFlight.erase(hash);
 }
 
-void AddGrapheneBlockInFlight(CNode *pfrom, uint256 hash)
+void AddGrapheneBlockInFlight(CNode *pfrom, const uint256 &hash)
 {
     LOCK(pfrom->cs_mapgrapheneblocksinflight);
     pfrom->mapGrapheneBlocksInFlight.insert(

--- a/src/graphene.cpp
+++ b/src/graphene.cpp
@@ -462,19 +462,16 @@ bool CGrapheneBlock::process(CNode *pfrom,
         LOCK(orphanpool.cs);
         for (auto &kv : orphanpool.mapOrphanTransactions)
         {
-            uint256 hash = kv.first;
-
-            uint64_t cheapHash = hash.GetCheapHash();
+            uint64_t cheapHash = kv.first.GetCheapHash();
 
             if (mapPartialTxHash.count(cheapHash)) // Check for collisions
                 collision = true;
 
-            mapPartialTxHash[cheapHash] = hash;
+            mapPartialTxHash[cheapHash] = kv.first;
         }
 
         // We don't have to keep the lock on mempool.cs here to do mempool.queryHashes
         // but we take the lock anyway so we don't have to re-lock again later.
-        ////////////////////// What is cs_xval for?
         LOCK(cs_xval);
         mempool.queryHashes(memPoolHashes);
 

--- a/src/graphene.h
+++ b/src/graphene.h
@@ -235,11 +235,11 @@ public:
     std::string ReRequestedTxToString();
     std::string MempoolLimiterBytesSavedToString();
 
-    bool CheckGrapheneBlockTimer(uint256 hash);
-    void ClearGrapheneBlockTimer(uint256 hash);
+    bool CheckGrapheneBlockTimer(const uint256 &hash);
+    void ClearGrapheneBlockTimer(const uint256 &hash);
 
     void ClearGrapheneBlockData(CNode *pfrom);
-    void ClearGrapheneBlockData(CNode *pfrom, uint256 hash);
+    void ClearGrapheneBlockData(CNode *pfrom, const uint256 &hash);
     void ClearGrapheneBlockStats();
 
     uint64_t AddGrapheneBlockBytes(uint64_t, CNode *pfrom);
@@ -257,8 +257,8 @@ bool CanGrapheneBlockBeDownloaded(CNode *pto);
 void ConnectToGrapheneBlockNodes();
 void CheckNodeSupportForGrapheneBlocks();
 bool ClearLargestGrapheneBlockAndDisconnect(CNode *pfrom);
-void ClearGrapheneBlockInFlight(CNode *pfrom, uint256 hash);
-void AddGrapheneBlockInFlight(CNode *pfrom, uint256 hash);
+void ClearGrapheneBlockInFlight(CNode *pfrom, const uint256 &hash);
+void AddGrapheneBlockInFlight(CNode *pfrom, const uint256 &hash);
 void SendGrapheneBlock(CBlockRef pblock, CNode *pfrom, const CInv &inv);
 bool IsGrapheneBlockValid(CNode *pfrom, const CBlockHeader &header);
 bool HandleGrapheneBlockRequest(CDataStream &vRecv, CNode *pfrom, const CChainParams &chainparams);

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -1295,7 +1295,7 @@ std::string CThinBlockData::FullTxToString()
 // block inventory is from a non XTHIN node then we will continue to wait for block announcements until either we
 // get one from an XTHIN capable node or the timer is exceeded.  If the timer is exceeded before receiving an
 // announcement from an XTHIN node then we just download a full block instead of an xthin.
-bool CThinBlockData::CheckThinblockTimer(uint256 hash)
+bool CThinBlockData::CheckThinblockTimer(const uint256 &hash)
 {
     LOCK(cs_mapThinBlockTimer);
     if (!mapThinBlockTimer.count(hash))
@@ -1319,7 +1319,7 @@ bool CThinBlockData::CheckThinblockTimer(uint256 hash)
 }
 
 // The timer is cleared as soon as we request a block or thinblock.
-void CThinBlockData::ClearThinBlockTimer(uint256 hash)
+void CThinBlockData::ClearThinBlockTimer(const uint256 &hash)
 {
     LOCK(cs_mapThinBlockTimer);
     if (mapThinBlockTimer.count(hash))
@@ -1348,7 +1348,7 @@ void CThinBlockData::ClearThinBlockData(CNode *pnode)
         thindata.GetThinBlockBytes());
 }
 
-void CThinBlockData::ClearThinBlockData(CNode *pnode, uint256 hash)
+void CThinBlockData::ClearThinBlockData(CNode *pnode, const uint256 &hash)
 {
     // We must make sure to clear the thinblock data first before clearing the thinblock in flight.
     ClearThinBlockData(pnode);
@@ -1545,13 +1545,13 @@ bool ClearLargestThinBlockAndDisconnect(CNode *pfrom)
     return false;
 }
 
-void ClearThinBlockInFlight(CNode *pfrom, uint256 hash)
+void ClearThinBlockInFlight(CNode *pfrom, const uint256 &hash)
 {
     LOCK(pfrom->cs_mapthinblocksinflight);
     pfrom->mapThinBlocksInFlight.erase(hash);
 }
 
-void AddThinBlockInFlight(CNode *pfrom, uint256 hash)
+void AddThinBlockInFlight(CNode *pfrom, const uint256 &hash)
 {
     LOCK(pfrom->cs_mapthinblocksinflight);
     pfrom->mapThinBlocksInFlight.insert(

--- a/src/thinblock.h
+++ b/src/thinblock.h
@@ -226,11 +226,11 @@ public:
     std::string ThinBlockToString();
     std::string FullTxToString();
 
-    bool CheckThinblockTimer(uint256 hash);
-    void ClearThinBlockTimer(uint256 hash);
+    bool CheckThinblockTimer(const uint256 &hash);
+    void ClearThinBlockTimer(const uint256 &hash);
 
     void ClearThinBlockData(CNode *pfrom);
-    void ClearThinBlockData(CNode *pfrom, uint256 hash);
+    void ClearThinBlockData(CNode *pfrom, const uint256 &hash);
     void ClearThinBlockStats();
 
     uint64_t AddThinBlockBytes(uint64_t, CNode *pfrom);
@@ -248,8 +248,8 @@ bool CanThinBlockBeDownloaded(CNode *pto);
 void ConnectToThinBlockNodes();
 void CheckNodeSupportForThinBlocks();
 bool ClearLargestThinBlockAndDisconnect(CNode *pfrom);
-void ClearThinBlockInFlight(CNode *pfrom, uint256 hash);
-void AddThinBlockInFlight(CNode *pfrom, uint256 hash);
+void ClearThinBlockInFlight(CNode *pfrom, const uint256 &hash);
+void AddThinBlockInFlight(CNode *pfrom, const uint256 &hash);
 void SendXThinBlock(CBlockRef pblock, CNode *pfrom, const CInv &inv);
 bool IsThinBlockValid(CNode *pfrom, const std::vector<CTransaction> &vMissingTx, const CBlockHeader &header);
 void BuildSeededBloomFilter(CBloomFilter &memPoolFilter,


### PR DESCRIPTION
better use of references, prevent unnecessary copy, use GUARDED_BY for cs_xval