### PR TITLE
Remove code relating to connect-graphene and connect-graphene-force

### DIFF
--- a/src/allowed_args.cpp
+++ b/src/allowed_args.cpp
@@ -300,9 +300,6 @@ static void addConnectionOptions(AllowedArgs &allowedArgs)
             _("Connect to a thinblock node(s). Blocks will only be downloaded from a thinblock peer.  If no "
               "connections "
               "are possible then regular blocks will then be downloaded form any other connected peers"))
-        .addArg("connect-graphene=<ip:port>", requiredStr,
-            _("Connect to graphene node(s). Blocks will only be downloaded from a graphene capable peer.  If no "
-              "connections are possible then regular blocks will then be downloaded form any other connected peers"))
         .addArg("discover", optionalBool,
             _("Discover own IP addresses (default: 1 when listening and no -externalip or -proxy)"))
         .addArg("dns", optionalBool, _("Allow DNS lookups for -addnode, -seednode and -connect") + " " +
@@ -542,8 +539,6 @@ static void addDebuggingOptions(AllowedArgs &allowedArgs, HelpMessageMode mode)
                          DEFAULT_PRINTPRIORITY))
         .addDebugArg("connect-thinblock-force", optionalBool,
             strprintf("Force download of thinblocks from connect-thinblock peers (default: %u)", false))
-        .addDebugArg("connect-graphene-force", optionalBool,
-            strprintf("Force download of graphene blocks from connect-graphene peers (default: %u)", false))
 #ifdef ENABLE_WALLET
         .addDebugArg("privdb", optionalBool,
             strprintf("Sets the DB_PRIVATE flag in the wallet db environment (default: %u)", DEFAULT_WALLET_PRIVDB))

--- a/src/graphene.h
+++ b/src/graphene.h
@@ -253,12 +253,9 @@ public:
 extern CGrapheneBlockData graphenedata; // Singleton class
 
 
-bool HaveConnectGrapheneNodes();
 bool HaveGrapheneNodes();
 bool IsGrapheneBlockEnabled();
 bool CanGrapheneBlockBeDownloaded(CNode *pto);
-void ConnectToGrapheneBlockNodes();
-void CheckNodeSupportForGrapheneBlocks();
 bool ClearLargestGrapheneBlockAndDisconnect(CNode *pfrom);
 void ClearGrapheneBlockInFlight(CNode *pfrom, const uint256 &hash);
 void AddGrapheneBlockInFlight(CNode *pfrom, const uint256 &hash);

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1759,11 +1759,8 @@ void ThreadOpenConnections()
     // Connect to all "connect-thinblock" peers
     ConnectToThinBlockNodes();
 
-    // Connect to all "connect-graphene" peers
-    ConnectToGrapheneBlockNodes();
-
-    // NOTE: If we are in the block above, then no seeding should occur as "-connect", "-connect-thinblock"
-    // and "connect-graphene" are intended as "only make outbound connections to the configured nodes".
+    // NOTE: If we are in the block above, then no seeding should occur as "-connect" and "-connect-thinblock"
+    // are intended as "only make outbound connections to the configured nodes".
 
     // Initiate network connections
     int64_t nStart = GetTime();

--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -439,7 +439,7 @@ bool CRequestManager::RequestBlock(CNode *pfrom, CInv obj)
     // Ask for Graphene blocks
     if (IsGrapheneBlockEnabled() && IsChainNearlySyncd())
     {
-        if (HaveConnectGrapheneNodes() || (HaveGrapheneNodes() && graphenedata.CheckGrapheneBlockTimer(obj.hash)))
+        if (HaveGrapheneNodes() && graphenedata.CheckGrapheneBlockTimer(obj.hash))
         {
             // Must download a graphene block from a graphene enabled peer.
             // We can only request one graphene block per peer at a time.


### PR DESCRIPTION
This functionality is hopelessly broken in RequestBlock(). While it
could no doubt be made to work again, the amount of work and logic
required far outweighs any benefit. In the past these functions were
used only in the very beginning of XTHIN's history and was primarily
used to test over the GFC. They were superceded by AddNode() and really
no longer have any useful purpose. It is also likely that
connect-thinblock and connect-thinblock-force will also be removed
at a future date.