### PR TITLE
Remove MIN_GRAPHENE_NODES

### DIFF
--- a/src/allowed_args.cpp
+++ b/src/allowed_args.cpp
@@ -328,9 +328,6 @@ static void addConnectionOptions(AllowedArgs &allowedArgs)
         .addArg("min-xthin-nodes=<n>", requiredInt,
             strprintf(_("Minimum number of xthin nodes to automatically find and connect (default: %d)"),
                     MIN_XTHIN_NODES))
-        .addArg("min-graphene-nodes=<n>", requiredInt,
-            strprintf(_("Minimum number of graphene nodes to automatically find and connect (default: %d)"),
-                    MIN_GRAPHENE_NODES))
         .addArg("onion=<ip:port>", requiredStr,
             strprintf(_("Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: %s)"), "-proxy"))
         .addArg("onlynet=<net>", requiredStr, _("Only connect to nodes in network <net> (ipv4, ipv6 or onion)"))

--- a/src/graphene.cpp
+++ b/src/graphene.cpp
@@ -1244,7 +1244,6 @@ void CGrapheneBlockData::DeleteGrapheneBlockBytes(uint64_t bytes, CNode *pfrom)
 
 void CGrapheneBlockData::ResetGrapheneBlockBytes() { nGrapheneBlockBytes.store(0); }
 uint64_t CGrapheneBlockData::GetGrapheneBlockBytes() { return nGrapheneBlockBytes.load(); }
-
 bool HaveGrapheneNodes()
 {
     {

--- a/src/net.h
+++ b/src/net.h
@@ -83,8 +83,6 @@ static const unsigned int DEFAULT_MAX_PEER_CONNECTIONS = 125;
 static const unsigned int DEFAULT_MAX_OUTBOUND_CONNECTIONS = 16;
 /** BU: The minimum number of xthin nodes to connect */
 static const uint8_t MIN_XTHIN_NODES = 8;
-/** BU: The minimum number of graphene nodes to connect */
-static const uint8_t MIN_GRAPHENE_NODES = 8;
 /** BU: The daily maximum disconnects while searching for xthin nodes to connect */
 static const unsigned int MAX_DISCONNECTS = 200;
 /** The default for -maxuploadtarget. 0 = Unlimited */


### PR DESCRIPTION
This feature is not enabled and will likely not need to be because
we already use MIN_XTHIN_NODES.  And since graphene nodes will
typcially have xthin turned on, we don't need to add additional
connection logic for graphene nodes.