### PR TITLE
Randomize the graphene and thinblock timers.

### DIFF
--- a/src/graphene.cpp
+++ b/src/graphene.cpp
@@ -875,12 +875,6 @@ void CGrapheneBlockData::UpdateInBoundReRequestedTx(int nReRequestedTx)
     updateStats(mapGrapheneBlocksInBoundReRequestedTx, nReRequestedTx);
 }
 
-void CGrapheneBlockData::UpdateMempoolLimiterBytesSaved(unsigned int nBytesSaved)
-{
-    LOCK(cs_graphenestats);
-    nMempoolLimiterBytesSaved += nBytesSaved;
-}
-
 std::string CGrapheneBlockData::ToString()
 {
     LOCK(cs_graphenestats);
@@ -1121,15 +1115,6 @@ std::string CGrapheneBlockData::ReRequestedTxToString()
     return ss.str();
 }
 
-std::string CGrapheneBlockData::MempoolLimiterBytesSavedToString()
-{
-    LOCK(cs_graphenestats);
-    double size = (double)nMempoolLimiterBytesSaved();
-    std::ostringstream ss;
-    ss << "Graphene block mempool limiting has saved " << formatInfoUnit(size) << " of bandwidth";
-    return ss.str();
-}
-
 // Preferential Graphene Block Timer:
 // The purpose of the timer is to ensure that we more often download an GRAPHENEBLOCK rather than a full block.
 // The timer is started when we receive the first announcement indicating there is a new block to download.  If the
@@ -1219,7 +1204,6 @@ void CGrapheneBlockData::ClearGrapheneBlockStats()
     nInBoundBlocks.Clear();
     nOutBoundBlocks.Clear();
     nDecodeFailures.Clear();
-    nMempoolLimiterBytesSaved.Clear();
     nTotalMemPoolInfoBytes.Clear();
     nTotalFilterBytes.Clear();
     nTotalIbltBytes.Clear();

--- a/src/graphene.cpp
+++ b/src/graphene.cpp
@@ -1307,12 +1307,11 @@ void SendGrapheneBlock(CBlockRef pblock, CNode *pfrom, const CInv &inv, const CM
         try
         {
             CGrapheneBlock grapheneBlock(MakeBlockRef(*pblock), mempoolinfo.nTx);
-            int nSizeBlock = ::GetSerializeSize(*pblock, SER_NETWORK, PROTOCOL_VERSION);
+            int nSizeBlock = pblock->GetBlockSize();
             int nSizeGrapheneBlock = ::GetSerializeSize(grapheneBlock, SER_NETWORK, PROTOCOL_VERSION);
 
-            if (nSizeGrapheneBlock + MIN_MEMPOOL_INFO_BYTES >
-                nSizeBlock) // If graphene block is larger than a regular block then
-            // send a regular block instead
+            // If graphene block is larger than a regular block then send a regular block instead
+            if (nSizeGrapheneBlock > nSizeBlock)
             {
                 pfrom->PushMessage(NetMsgType::BLOCK, *pblock);
                 LOG(GRAPHENE, "Sent regular block instead - graphene block size: %d vs block size: %d => peer: %s\n",

--- a/src/graphene.h
+++ b/src/graphene.h
@@ -165,7 +165,6 @@ private:
     CStatHistory<uint64_t> nInBoundBlocks;
     CStatHistory<uint64_t> nOutBoundBlocks;
     CStatHistory<uint64_t> nDecodeFailures;
-    CStatHistory<uint64_t> nMempoolLimiterBytesSaved;
     CStatHistory<uint64_t> nTotalMemPoolInfoBytes;
     CStatHistory<uint64_t> nTotalFilterBytes;
     CStatHistory<uint64_t> nTotalIbltBytes;
@@ -222,7 +221,6 @@ public:
     void UpdateResponseTime(double nResponseTime);
     void UpdateValidationTime(double nValidationTime);
     void UpdateInBoundReRequestedTx(int nReRequestedTx);
-    void UpdateMempoolLimiterBytesSaved(unsigned int nBytesSaved);
     std::string ToString();
     std::string InBoundPercentToString();
     std::string OutBoundPercentToString();
@@ -236,7 +234,6 @@ public:
     std::string ResponseTimeToString();
     std::string ValidationTimeToString();
     std::string ReRequestedTxToString();
-    std::string MempoolLimiterBytesSavedToString();
 
     bool CheckGrapheneBlockTimer(const uint256 &hash);
     void ClearGrapheneBlockTimer(const uint256 &hash);

--- a/src/graphene.h
+++ b/src/graphene.h
@@ -256,7 +256,7 @@ bool CanGrapheneBlockBeDownloaded(CNode *pto);
 bool ClearLargestGrapheneBlockAndDisconnect(CNode *pfrom);
 void ClearGrapheneBlockInFlight(CNode *pfrom, const uint256 &hash);
 void AddGrapheneBlockInFlight(CNode *pfrom, const uint256 &hash);
-void SendGrapheneBlock(CBlockRef pblock, CNode *pfrom, const CInv &inv);
+void SendGrapheneBlock(CBlockRef pblock, CNode *pfrom, const CInv &inv, const CMemPoolInfo &mempoolinfo);
 bool IsGrapheneBlockValid(CNode *pfrom, const CBlockHeader &header);
 bool HandleGrapheneBlockRequest(CDataStream &vRecv, CNode *pfrom, const CChainParams &chainparams);
 CMemPoolInfo GetGrapheneMempoolInfo();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5023,17 +5023,15 @@ void static ProcessGetData(CNode *pfrom, const Consensus::Params &consensusParam
             boost::this_thread::interruption_point();
             it++;
 
-            // BUIP010 Xtreme Thinblocks: if (inv.type == MSG_BLOCK || inv.type == MSG_FILTERED_BLOCK)
-            if (inv.type == MSG_BLOCK || inv.type == MSG_FILTERED_BLOCK || inv.type == MSG_THINBLOCK ||
-                inv.type == MSG_XTHINBLOCK || inv.type == MSG_GRAPHENEBLOCK)
+            if (inv.type == MSG_BLOCK || inv.type == MSG_FILTERED_BLOCK)
             {
-                bool send = false;
+                bool fSend = false;
                 BlockMap::iterator mi = mapBlockIndex.find(inv.hash);
                 if (mi != mapBlockIndex.end())
                 {
                     if (chainActive.Contains(mi->second))
                     {
-                        send = true;
+                        fSend = true;
                     }
                     else
                     {
@@ -5041,11 +5039,11 @@ void static ProcessGetData(CNode *pfrom, const Consensus::Params &consensusParam
                         // To prevent fingerprinting attacks, only send blocks outside of the active
                         // chain if they are valid, and no more than a month older (both in time, and in
                         // best equivalent proof of work) than the best header chain we know about.
-                        send = mi->second->IsValid(BLOCK_VALID_SCRIPTS) && (pindexBestHeader != NULL) &&
+                        fSend = mi->second->IsValid(BLOCK_VALID_SCRIPTS) && (pindexBestHeader != NULL) &&
                                (pindexBestHeader->GetBlockTime() - mi->second->GetBlockTime() < nOneMonth) &&
                                (GetBlockProofEquivalentTime(
                                     *pindexBestHeader, *mi->second, *pindexBestHeader, consensusParams) < nOneMonth);
-                        if (!send)
+                        if (!fSend)
                         {
                             LOGA("%s: ignoring request from peer=%i for old block that isn't in the main chain\n",
                                 __func__, pfrom->GetId());
@@ -5053,8 +5051,8 @@ void static ProcessGetData(CNode *pfrom, const Consensus::Params &consensusParam
                         else
                         { // BU: don't relay excessive blocks
                             if (mi->second->nStatus & BLOCK_EXCESSIVE)
-                                send = false;
-                            if (!send)
+                                fSend = false;
+                            if (!fSend)
                                 LOGA("%s: ignoring request from peer=%i for excessive block of height %d not on "
                                      "the main chain\n",
                                     __func__, pfrom->GetId(), mi->second->nHeight);
@@ -5066,7 +5064,7 @@ void static ProcessGetData(CNode *pfrom, const Consensus::Params &consensusParam
                 // disconnect node in case we have reached the outbound limit for serving historical blocks
                 // never disconnect whitelisted nodes
                 static const int nOneWeek = 7 * 24 * 60 * 60; // assume > 1 week = historical
-                if (send && CNode::OutboundTargetReached(true) &&
+                if (fSend && CNode::OutboundTargetReached(true) &&
                     (((pindexBestHeader != NULL) &&
                          (pindexBestHeader->GetBlockTime() - mi->second->GetBlockTime() > nOneWeek)) ||
                         inv.type == MSG_FILTERED_BLOCK) &&
@@ -5076,11 +5074,11 @@ void static ProcessGetData(CNode *pfrom, const Consensus::Params &consensusParam
 
                     // disconnect node
                     pfrom->fDisconnect = true;
-                    send = false;
+                    fSend = false;
                 }
                 // Pruned nodes may have deleted the block, so check whether
                 // it's available before trying to send.
-                if (send && (mi->second->nStatus & BLOCK_HAVE_DATA))
+                if (fSend && (mi->second->nStatus & BLOCK_HAVE_DATA))
                 {
                     // Send block from disk
                     CBlock block;
@@ -5098,23 +5096,6 @@ void static ProcessGetData(CNode *pfrom, const Consensus::Params &consensusParam
                             pfrom->blocksSent += 1;
                             pfrom->PushMessage(NetMsgType::BLOCK, block);
                         }
-
-                        // BUIP010 Xtreme Thinblocks: begin section
-                        else if (inv.type == MSG_THINBLOCK || inv.type == MSG_XTHINBLOCK)
-                        {
-                            LOG(THIN, "Sending xthin by INV queue getdata message\n");
-                            SendXThinBlock(MakeBlockRef(block), pfrom, inv);
-                        }
-                        // BUIP010 Xtreme Thinblocks: end section
-
-                        // BUIPXXX Graphene blocks: begin section
-                        else if (inv.type == MSG_GRAPHENEBLOCK)
-                        {
-                            LOG(GRAPHENE, "Sending graphene block by INV queue getdata message\n");
-                            SendGrapheneBlock(MakeBlockRef(block), pfrom, inv);
-                        }
-                        // BUIPXXX Graphene blocks: end section
-
                         else // MSG_FILTERED_BLOCK)
                         {
                             LOCK(pfrom->cs_filter);
@@ -5159,7 +5140,7 @@ void static ProcessGetData(CNode *pfrom, const Consensus::Params &consensusParam
             else if (inv.IsKnownType())
             {
                 // Send stream from relay memory
-                bool pushed = false;
+                bool fPushed = false;
                 {
                     CDataStream cd(0, 0);
                     if (1)
@@ -5171,15 +5152,15 @@ void static ProcessGetData(CNode *pfrom, const Consensus::Params &consensusParam
                         if (mi != mapRelay.end())
                         {
                             cd = (*mi).second; // I have to copy, because .second may be deleted once lock is released
-                            pushed = true;
+                            fPushed = true;
                         }
                     }
-                    if (pushed)
+                    if (fPushed)
                     {
                         pfrom->PushMessage(inv.GetCommand(), cd);
                     }
                 }
-                if (!pushed && inv.type == MSG_TX)
+                if (!fPushed && inv.type == MSG_TX)
                 {
                     CTxMemPoolEntry txe;
                     if (mempool.lookup(inv.hash, txe))
@@ -5191,12 +5172,12 @@ void static ProcessGetData(CNode *pfrom, const Consensus::Params &consensusParam
                             ss.reserve(1000);
                             ss << txe.GetTx();
                             pfrom->PushMessage(NetMsgType::TX, ss);
-                            pushed = true;
+                            fPushed = true;
                             pfrom->txsSent += 1;
                         }
                     }
                 }
-                if (!pushed)
+                if (!fPushed)
                 {
                     vNotFound.push_back(inv);
                 }
@@ -5209,8 +5190,7 @@ void static ProcessGetData(CNode *pfrom, const Consensus::Params &consensusParam
             // priority messages and we don't want to sit here processing a large number of messages
             // while we hold the cs_main lock, but rather allow these messages to be sent first and
             // process the return message before potentially reading from the queue again.
-            if (inv.type == MSG_BLOCK || inv.type == MSG_FILTERED_BLOCK || inv.type == MSG_THINBLOCK ||
-                inv.type == MSG_XTHINBLOCK || inv.type == MSG_GRAPHENEBLOCK)
+            if (inv.type == MSG_BLOCK || inv.type == MSG_FILTERED_BLOCK)
                 break;
         }
     }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -591,63 +591,34 @@ bool CNode::ReceiveMsgBytes(const char *pch, unsigned int nBytes)
 
         if (msg.complete())
         {
-            // BU: connection slot attack mitigation.  We don't count PONG responses as bytes received. We don't want to
-            // include
-            //     bytes sent or received for nodes that just connect and listen to INV messages.
+            // Connection slot attack mitigation.  We don't want to add useful bytes for outgoing INV, PING, ADDR,
+            // VERSION or VERACK messages since attackers will often just connect and listen to INV messages.
+            // We want to make sure that connected nodes are doing useful work in sending us data or requesting data.
             std::string strCommand = msg.hdr.GetCommand();
             if (strCommand != NetMsgType::PONG && strCommand != NetMsgType::PING && strCommand != NetMsgType::ADDR &&
                 strCommand != NetMsgType::VERSION && strCommand != NetMsgType::VERACK)
             {
-                if (strCommand == NetMsgType::GET_GRAPHENE)
-                    LOG(GRAPHENE, "ReceiveMsgBytes GET_GRAPHENE\n");
-                else if (strCommand == NetMsgType::GRAPHENEBLOCK)
-                    LOG(GRAPHENE, "ReceiveMsgBytes GRAPHENEBLOCK\n");
-                else if (strCommand == NetMsgType::GRAPHENETX)
-                    LOG(GRAPHENE, "ReceiveMsgBytes GRAPHENETX\n");
-                else if (strCommand == NetMsgType::GET_GRAPHENETX)
-                    LOG(GRAPHENE, "ReceiveMsgBytes GET_GRAPHENETX\n");
-                else if (strCommand == NetMsgType::GET_XTHIN)
-                    LOG(THIN, "ReceiveMsgBytes GET_XTHIN\n");
-                else if (strCommand == NetMsgType::XTHINBLOCK)
-                    LOG(THIN, "ReceiveMsgBytes XTHINBLOCK\n");
-                else if (strCommand == NetMsgType::THINBLOCK)
-                    LOG(THIN, "ReceiveMsgBytes THINBLOCK\n");
-                else if (strCommand == NetMsgType::XBLOCKTX)
-                    LOG(THIN, "ReceiveMsgBytes XBLOCKTX\n");
-                else if (strCommand == NetMsgType::GET_XBLOCKTX)
-                    LOG(THIN, "ReceiveMsgBytes GET_XBLOCKTX\n");
-
-
                 nActivityBytes += msg.hdr.nMessageSize;
 
-                // BU: furthermore, if the message is a priority message then move from the back to the front of the
-                // deque
+                // If the message is a priority message then move from the back to the front of the deque.
+                //
                 // NOTE: for GET_XTHIN we don't jump the queue on test environments because the GET_XTHIN can get ahead
-                // of
-                // a previous GET_XTHIN/HEADER requests and result in a DOS if the block returns out of order and with
-                // no headers
-                // in the block index or the setblockindexcandidates.
+                // of a previous GET_XTHIN/HEADER requests and result in a DOS if the block returns out of order and
+                // with no headers in the block index or the setblockindexcandidates.
                 if ((strCommand == NetMsgType::GET_XTHIN && Params().NetworkIDString() == "main") ||
                     strCommand == NetMsgType::XTHINBLOCK || strCommand == NetMsgType::THINBLOCK ||
-                    strCommand == NetMsgType::XBLOCKTX || strCommand == NetMsgType::GET_XBLOCKTX)
+                    strCommand == NetMsgType::XBLOCKTX || strCommand == NetMsgType::GET_XBLOCKTX ||
+                    strCommand == NetMsgType::GET_GRAPHENE || strCommand == NetMsgType::GRAPHENEBLOCK ||
+                    strCommand == NetMsgType::GRAPHENETX || strCommand == NetMsgType::GET_GRAPHENETX)
                 {
-                    // Move the this last message to the front of the queue.
+                    LOG(THIN | GRAPHENE, "ReceiveMsgBytes %s\n", strCommand);
+
+                    // Move the this message to the front of the queue.
                     std::rotate(vRecvMsg.begin(), vRecvMsg.end() - 1, vRecvMsg.end());
 
                     std::string strFirstMsgCommand = vRecvMsg[0].hdr.GetCommand();
                     DbgAssert(strFirstMsgCommand == strCommand, );
-                    LOG(THIN, "Receive Queue: pushed %s to the front of the queue\n", strFirstMsgCommand);
-                }
-                else if ((strCommand == NetMsgType::GET_GRAPHENE && Params().NetworkIDString() == "main") ||
-                         strCommand == NetMsgType::GRAPHENEBLOCK || strCommand == NetMsgType::GRAPHENETX ||
-                         strCommand == NetMsgType::GET_GRAPHENETX)
-                {
-                    // Move the this last message to the front of the queue.
-                    std::rotate(vRecvMsg.begin(), vRecvMsg.end() - 1, vRecvMsg.end());
-
-                    std::string strFirstMsgCommand = vRecvMsg[0].hdr.GetCommand();
-                    DbgAssert(strFirstMsgCommand == strCommand, );
-                    LOG(GRAPHENE, "Receive Queue: pushed %s to the front of the queue\n", strFirstMsgCommand);
+                    LOG(THIN | GRAPHENE, "Receive Queue: pushed %s to the front of the queue\n", strFirstMsgCommand);
                 }
             }
             // BU: end
@@ -3019,9 +2990,9 @@ void CNode::EndMessage() UNLOCK_FUNCTION(cs_vSend)
 
     LOG(NET, "(%d bytes) peer=%d\n", nSize, id);
 
-    // BU: connection slot attack mitigation.  We don't want to add bytes for outgoing INV or PING
-    //     messages since attackers will often just connect and listen to INV messages.  We want to make
-    //     sure that connected nodes are really doing useful work in sending us data or requesting data.
+    // Connection slot attack mitigation.  We don't want to add useful bytes for outgoing INV, PING, ADDR,
+    // VERSION or VERACK messages since attackers will often just connect and listen to INV messages.
+    // We want to make sure that connected nodes are doing useful work in sending us data or requesting data.
     std::deque<CSerializeData>::iterator it;
     char strCommand[CMessageHeader::COMMAND_SIZE + 1];
     strncpy(strCommand, &(*(ssSend.begin() + MESSAGE_START_SIZE)), CMessageHeader::COMMAND_SIZE);
@@ -3032,10 +3003,12 @@ void CNode::EndMessage() UNLOCK_FUNCTION(cs_vSend)
     {
         nActivityBytes += nSize;
 
-        // BU: furthermore, if the message is a priority message then move to the front of the deque
+        // If the message is a priority message then move to the front of the deque
         if (strcmp(strCommand, NetMsgType::GET_XTHIN) == 0 || strcmp(strCommand, NetMsgType::XTHINBLOCK) == 0 ||
             strcmp(strCommand, NetMsgType::THINBLOCK) == 0 || strcmp(strCommand, NetMsgType::XBLOCKTX) == 0 ||
-            strcmp(strCommand, NetMsgType::GET_XBLOCKTX) == 0)
+            strcmp(strCommand, NetMsgType::GET_XBLOCKTX) == 0 || strcmp(strCommand, NetMsgType::GET_GRAPHENE) == 0 ||
+            strcmp(strCommand, NetMsgType::GRAPHENEBLOCK) == 0 || strcmp(strCommand, NetMsgType::GRAPHENETX) == 0 ||
+            strcmp(strCommand, NetMsgType::GET_GRAPHENETX) == 0)
         {
             it = vSendMsg.insert(vSendMsg.begin(), CSerializeData());
             LOG(THIN, "Send Queue: pushed %s to the front of the queue\n", strCommand);

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2952,7 +2952,6 @@ CNode::~CNode()
     // BUIPXXX - Graphene blocks - begin section
     mapGrapheneBlocksInFlight.clear();
     grapheneBlockWaitingForTxns = -1;
-    nGrapheneMemPoolTx = -1;
     grapheneBlock.SetNull();
 
     fSuccessfullyConnected = false;

--- a/src/net.h
+++ b/src/net.h
@@ -398,8 +398,11 @@ public:
     uint64_t nLocalThinBlockBytes; // the bytes used in creating this thinblock, updated dynamically
     int nSizeThinBlock; // Original on-wire size of the block. Just used for reporting
     int thinBlockWaitingForTxns; // if -1 then not currently waiting
-    CCriticalSection cs_mapthinblocksinflight; // lock mapThinBlocksInFlight
-    std::map<uint256, CThinBlockInFlight> mapThinBlocksInFlight; // thin blocks in flight and the time requested.
+
+    // thin blocks in flight and the time they were requested.
+    CCriticalSection cs_mapthinblocksinflight;
+    std::map<uint256, CThinBlockInFlight> mapThinBlocksInFlight GUARDED_BY(cs_mapthinblocksinflight);
+
     double nGetXBlockTxCount; // Count how many get_xblocktx requests are made
     uint64_t nGetXBlockTxLastTime; // The last time a get_xblocktx request was made
     double nGetXthinCount; // Count how many get_xthin requests are made
@@ -419,9 +422,11 @@ public:
     int grapheneBlockWaitingForTxns; // if -1 then not currently waiting
     CCriticalSection cs_grapheneadditionaltxs; // lock grapheneAdditionalTxs
     std::vector<CTransactionRef> grapheneAdditionalTxs; // entire transactions included in graphene block
-    CCriticalSection cs_mapgrapheneblocksinflight; // lock mapGraheneBlocksInFlight
-    std::map<uint256, CGrapheneBlockInFlight>
-        mapGrapheneBlocksInFlight; // graphene blocks in flight and the time requested.
+
+    // graphene blocks in flight and the time they were requested.
+    CCriticalSection cs_mapgrapheneblocksinflight;
+    std::map<uint256, CGrapheneBlockInFlight> mapGrapheneBlocksInFlight GUARDED_BY(cs_mapgrapheneblocksinflight);
+
     double nGetGrapheneBlockTxCount; // Count how many get_xblocktx requests are made
     uint64_t nGetGrapheneBlockTxLastTime; // The last time a get_xblocktx request was made
     double nGetGrapheneCount; // Count how many get_graphene requests are made

--- a/src/net.h
+++ b/src/net.h
@@ -411,8 +411,6 @@ public:
     // BUIP010 Xtreme Thinblocks: end section
 
     // BUIPXXX Graphene blocks: begin section
-    CCriticalSection cs_ngraphenemempooltx; // lock nGrapheneMemPoolTx
-    int64_t nGrapheneMemPoolTx;
     CBlock grapheneBlock;
     std::vector<uint256> grapheneBlockHashes;
     std::map<uint64_t, uint32_t> grapheneMapHashOrderIndex;

--- a/src/parallel.cpp
+++ b/src/parallel.cpp
@@ -605,9 +605,9 @@ void HandleBlockMessageThread(CNode *pfrom, const string strCommand, CBlockRef p
                 inv.hash.ToString(), strCommand, (double)(GetTimeMicros() - startTime) / 1000000.0,
                 pfrom->GetLogName());
 
-            if (IsThinBlocksEnabled())
+            if (strCommand != NetMsgType::GRAPHENEBLOCK)
                 thindata.UpdateValidationTime(nValidationTime);
-            else if (IsGrapheneBlockEnabled())
+            else
                 graphenedata.UpdateValidationTime(nValidationTime);
         }
         else

--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -1245,18 +1245,28 @@ bool CRequestManager::MarkBlockAsReceived(const uint256 &hash, CNode *pnode)
 
         if (IsChainNearlySyncd())
         {
+            // Update the appropriate response time based on the type of block received.
             LOCK(cs_vNodes);
             for (CNode *pnode : vNodes)
             {
-                if (pnode->mapThinBlocksInFlight.size() > 0)
+                // Update Thinblock stats 
+                if (IsThinBlocksEnabled())
                 {
                     LOCK(pnode->cs_mapthinblocksinflight);
                     if (pnode->mapThinBlocksInFlight.count(hash))
                     {
-                        // Only update thinstats if this is actually a thinblock and not a regular block.
-                        // Sometimes we request a thinblock but then revert to requesting a regular block
-                        // as can happen when the thinblock preferential timer is exceeded.
                         thindata.UpdateResponseTime(nResponseTime);
+                        break;
+                    }
+                }
+
+                // Update Graphene stats 
+                if (IsGrapheneBlockEnabled())
+                {
+                    LOCK(pnode->cs_mapgrapheneblocksinflight);
+                    if (pnode->mapGrapheneBlocksInFlight.count(hash))
+                    {
+                        graphenedata.UpdateResponseTime(nResponseTime);
                         break;
                     }
                 }

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -579,7 +579,7 @@ UniValue clearblockstats(const UniValue &params, bool fHelp)
 
     if (IsThinBlocksEnabled())
         thindata.ClearThinBlockStats();
-    else if (IsGrapheneBlockEnabled())
+    if (IsGrapheneBlockEnabled())
         graphenedata.ClearGrapheneBlockStats();
 
     return NullUniValue;

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -478,8 +478,6 @@ static UniValue GetGrapheneStats()
         obj.push_back(Pair("outbound_percent", graphenedata.OutBoundPercentToString()));
         obj.push_back(Pair("response_time", graphenedata.ResponseTimeToString()));
         obj.push_back(Pair("validation_time", graphenedata.ValidationTimeToString()));
-        obj.push_back(Pair("outbound_mempool_info", graphenedata.OutBoundMemPoolInfoToString()));
-        obj.push_back(Pair("inbound_mempool_info", graphenedata.InBoundMemPoolInfoToString()));
         obj.push_back(Pair("filter", graphenedata.FilterToString()));
         obj.push_back(Pair("iblt", graphenedata.IbltToString()));
         obj.push_back(Pair("rank", graphenedata.RankToString()));

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -474,7 +474,6 @@ static UniValue GetGrapheneStats()
     if (enabled)
     {
         obj.push_back(Pair("summary", graphenedata.ToString()));
-        obj.push_back(Pair("mempool_limiter", graphenedata.MempoolLimiterBytesSavedToString()));
         obj.push_back(Pair("inbound_percent", graphenedata.InBoundPercentToString()));
         obj.push_back(Pair("outbound_percent", graphenedata.OutBoundPercentToString()));
         obj.push_back(Pair("response_time", graphenedata.ResponseTimeToString()));

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -1297,11 +1297,25 @@ std::string CThinBlockData::FullTxToString()
 // announcement from an XTHIN node then we just download a full block instead of an xthin.
 bool CThinBlockData::CheckThinblockTimer(const uint256 &hash)
 {
+    // Base time used to calculate the random timeout value.
+    static int64_t nTimeToWait = 10000;
+
     LOCK(cs_mapThinBlockTimer);
     if (!mapThinBlockTimer.count(hash))
     {
-        mapThinBlockTimer[hash] = GetTimeMillis();
-        LOG(THIN, "Starting Preferential Thinblock timer\n");
+        // The timeout limit is a random number betwee 8 and 12 seconds.
+        // This way a node connected to this one may download the block
+        // before the other node and thus be able to serve the other with
+        // a graphene block, rather than both nodes timing out and downloading
+        // a thinblock instead. This can happen at the margins of the BU network
+        // where we receive full blocks from peers that don't support graphene.
+        //
+        // To make the timeout random we adjust the start time of the timer forward
+        // or backward by a random amount plus or minus 2 seconds.
+        FastRandomContext insecure_rand(false);
+        uint64_t nOffset = nTimeToWait - (8000 + (insecure_rand.rand64() % 4000) + 1);
+        mapThinBlockTimer[hash] = GetTimeMillis() + nOffset;
+        LOG(THIN, "Starting Preferential Thinblock timer (%d millis)\n", nTimeToWait + nOffset);
     }
     else
     {
@@ -1309,7 +1323,7 @@ bool CThinBlockData::CheckThinblockTimer(const uint256 &hash)
         // If we have then we want to return false so that we can
         // proceed to download a regular block instead.
         uint64_t elapsed = GetTimeMillis() - mapThinBlockTimer[hash];
-        if (elapsed > 10000)
+        if (elapsed > nTimeToWait)
         {
             LOG(THIN, "Preferential Thinblock timer exceeded - downloading regular block instead\n");
             return false;


### PR DESCRIPTION
By randomizing the timeouts either plus or minus 2 seconds
the propagation of graphene and thinblocks is enhanced near
the margins of the BU network, where nodes can receive the block
announcment at the same time. When such nodes are connected to
each other they previously would timeout and default to either an
xthin, or full block download.  Also, for new users, or even for
testing purposes it is also helpful in seeing a greater proportion
of graphene blocks being send or received when there a limited
number of graphene peers available.