### PR TITLE
Pr973

### DIFF
--- a/src/iblt.cpp
+++ b/src/iblt.cpp
@@ -74,10 +74,11 @@ CIblt::CIblt()
 {
     n_hash = 1;
     is_modified = false;
+    version = 0;
 }
 
-CIblt::CIblt(size_t _expectedNumEntries) : is_modified(false) { CIblt::resize(_expectedNumEntries); }
-CIblt::CIblt(const CIblt &other) : is_modified(false)
+CIblt::CIblt(size_t _expectedNumEntries) : is_modified(false), version(0) { CIblt::resize(_expectedNumEntries); }
+CIblt::CIblt(const CIblt &other) : is_modified(false), version(0)
 {
     n_hash = other.n_hash;
     hashTable = other.hashTable;

--- a/src/iblt.h
+++ b/src/iblt.h
@@ -109,6 +109,10 @@ public:
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream &s, Operation ser_action)
     {
+        READWRITE(COMPACTSIZE(version));
+        if (ser_action.ForRead() && version != 0)
+            throw std::ios_base::failure("Only IBLT version zero is currently known.");
+
         READWRITE(n_hash);
         if (ser_action.ForRead() && n_hash == 0)
         {
@@ -122,6 +126,7 @@ public:
 private:
     void _insert(int plusOrMinus, uint64_t k, const std::vector<uint8_t> &v);
 
+    uint64_t version;
     uint8_t n_hash;
     bool is_modified;
 


### PR DESCRIPTION
Two more ideas to ponder:

- a version field for CIBlt
- an easy way to reduce the key checksum entropy amount for easier testing of IBLT failure modes during testing (mask has to be manually edited in the code)
