### PR TITLE
Exploration of variable checksum in IBLT

### DIFF
--- a/qa/rpc-tests/graphene_optimized.py
+++ b/qa/rpc-tests/graphene_optimized.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+# Copyright (c) 2018 The Bitcoin Unlimited developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+
+from grapheneblocks import GrapheneBlockTest
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+
+
+class GrapheneOptimizedTest(GrapheneBlockTest):
+    
+    def setup_network(self, split=False):
+        node_opts = [
+            "-rpcservertimeout=0",
+            "-debug=graphene",
+            "-use-grapheneblocks=1",
+            "-use-thinblocks=0",
+            "-compute-optimize-graphene=1",
+            "-excessiveblocksize=6000000",
+            "-blockprioritysize=6000000",
+            "-blockmaxsize=6000000"]
+
+        self.nodes = [
+            start_node(0, self.options.tmpdir, node_opts),
+            start_node(1, self.options.tmpdir, node_opts),
+            start_node(2, self.options.tmpdir, node_opts)
+        ]
+
+        interconnect_nodes(self.nodes)
+        self.is_network_split = False
+        self.sync_all()
+
+
+if __name__ == '__main__':
+    GrapheneOptimizedTest().main()

--- a/src/allowed_args.cpp
+++ b/src/allowed_args.cpp
@@ -658,6 +658,8 @@ static void addNodeRelayOptions(AllowedArgs &allowedArgs)
             DEFAULT_BLOOM_FILTER_TARGETING)
         .addArg("use-grapheneblocks", optionalBool,
             strprintf(_("Enable graphene to speed up the relay of blocks (default: %d)"), DEFAULT_USE_GRAPHENE_BLOCKS))
+        .addArg("compute-optimize-graphene", optionalBool,
+            strprintf(_("Use CPU optimized data structures for Graphene even if this could lead to somewhat larger blocks (default: %d)"), COMPUTE_OPTIMIZE_GRAPHENE))
         .addArg("use-compactblocks", optionalBool,
             strprintf(_("Enable compact blocks to speed up the relay of blocks (default: %d)"),
                     DEFAULT_USE_COMPACT_BLOCKS))

--- a/src/allowed_args.cpp
+++ b/src/allowed_args.cpp
@@ -659,7 +659,9 @@ static void addNodeRelayOptions(AllowedArgs &allowedArgs)
         .addArg("use-grapheneblocks", optionalBool,
             strprintf(_("Enable graphene to speed up the relay of blocks (default: %d)"), DEFAULT_USE_GRAPHENE_BLOCKS))
         .addArg("compute-optimize-graphene", optionalBool,
-            strprintf(_("Use CPU optimized data structures for Graphene even if this could lead to somewhat larger blocks (default: %d)"), COMPUTE_OPTIMIZE_GRAPHENE))
+            strprintf(_("Use CPU optimized data structures for Graphene even if this could lead to somewhat larger "
+                        "blocks (default: %d)"),
+                    COMPUTE_OPTIMIZE_GRAPHENE))
         .addArg("use-compactblocks", optionalBool,
             strprintf(_("Enable compact blocks to speed up the relay of blocks (default: %d)"),
                     DEFAULT_USE_COMPACT_BLOCKS))

--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -1351,8 +1351,6 @@ bool ClearLargestGrapheneBlockAndDisconnect(CNode *pfrom)
 
 void SendGrapheneBlock(CBlockRef pblock, CNode *pfrom, const CInv &inv, const CMemPoolInfo &mempoolinfo)
 {
-    pfrom->useSipHash = pfrom->xVersion.as_u64c(XVer::BU_GRAPHENE_VERSION_SUPPORTED) >= 2;
-
     if (inv.type == MSG_GRAPHENEBLOCK)
     {
         try

--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -53,6 +53,8 @@ CGrapheneBlock::CGrapheneBlock(const CBlockRef pblock,
     else if (version >= 3)
         grapheneSetVersion = 2;
 
+    FillShortTxIDSelector();
+
     std::vector<uint256> blockHashes;
     for (auto &tx : pblock->vtx)
     {

--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -53,6 +53,8 @@ CGrapheneBlock::CGrapheneBlock(const CBlockRef pblock,
     else if (version >= 3)
         grapheneSetVersion = 2;
 
+    FillShortTxIDSelector();
+
     std::vector<uint256> blockHashes;
     for (auto &tx : pblock->vtx)
     {
@@ -1518,6 +1520,13 @@ uint64_t GetShortID(uint64_t shorttxidk0, uint64_t shorttxidk1, const uint256 &t
     // but are instead unchanged from the default initialization value.
     DbgAssert(!(shorttxidk0 == 0 && shorttxidk1 == 0), );
 
+    static_assert(SHORTTXIDS_LENGTH == 8, "shorttxids calculation assumes 8-byte shorttxids");
+    return SipHashUint256(shorttxidk0, shorttxidk1, txhash) & 0xffffffffffffffL;
+}
+
+// Generate cheap hash from seeds using SipHash
+uint64_t GetShortID(uint64_t shorttxidk0, uint64_t shorttxidk1, const uint256& txhash) {
+    //return txhash.GetCheapHash();
     static_assert(SHORTTXIDS_LENGTH == 8, "shorttxids calculation assumes 8-byte shorttxids");
     return SipHashUint256(shorttxidk0, shorttxidk1, txhash) & 0xffffffffffffffL;
 }

--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -53,8 +53,6 @@ CGrapheneBlock::CGrapheneBlock(const CBlockRef pblock,
     else if (version >= 3)
         grapheneSetVersion = 2;
 
-    FillShortTxIDSelector();
-
     std::vector<uint256> blockHashes;
     for (auto &tx : pblock->vtx)
     {
@@ -1353,6 +1351,8 @@ bool ClearLargestGrapheneBlockAndDisconnect(CNode *pfrom)
 
 void SendGrapheneBlock(CBlockRef pblock, CNode *pfrom, const CInv &inv, const CMemPoolInfo &mempoolinfo)
 {
+    pfrom->useSipHash = pfrom->xVersion.as_u64c(XVer::BU_GRAPHENE_VERSION_SUPPORTED) >= 2;
+
     if (inv.type == MSG_GRAPHENEBLOCK)
     {
         try

--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -53,9 +53,12 @@ CGrapheneBlock::CGrapheneBlock(const CBlockRef pblock,
     else if (version >= 3)
         grapheneSetVersion = 2;
 
-    useSipHash = _useSipHash;
-    if (useSipHash)
+    version = _version;
+    if (version >= 2)
+    {
         FillShortTxIDSelector();
+        grapheneSetVersion = 1;
+    }
 
     std::vector<uint256> blockHashes;
     for (auto &tx : pblock->vtx)
@@ -1355,8 +1358,6 @@ bool ClearLargestGrapheneBlockAndDisconnect(CNode *pfrom)
 
 void SendGrapheneBlock(CBlockRef pblock, CNode *pfrom, const CInv &inv, const CMemPoolInfo &mempoolinfo)
 {
-    pfrom->useSipHash = pfrom->xVersion.as_u64c(XVer::BU_GRAPHENE_VERSION_SUPPORTED) >= 2;
-
     if (inv.type == MSG_GRAPHENEBLOCK)
     {
         try
@@ -1529,9 +1530,9 @@ uint64_t GetShortID(uint64_t shorttxidk0, uint64_t shorttxidk1, const uint256 &t
 }
 
 // Generate cheap hash from seeds using SipHash
-uint64_t GetShortID(uint64_t shorttxidk0, uint64_t shorttxidk1, const uint256 &txhash, bool useSipHash)
+uint64_t GetShortID(uint64_t shorttxidk0, uint64_t shorttxidk1, const uint256 &txhash, uint64_t grapheneVersion)
 {
-    if (!useSipHash)
+    if (grapheneVersion < 2)
         return txhash.GetCheapHash();
 
     static_assert(SHORTTXIDS_LENGTH == 8, "shorttxids calculation assumes 8-byte shorttxids");

--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -1351,6 +1351,8 @@ bool ClearLargestGrapheneBlockAndDisconnect(CNode *pfrom)
 
 void SendGrapheneBlock(CBlockRef pblock, CNode *pfrom, const CInv &inv, const CMemPoolInfo &mempoolinfo)
 {
+    pfrom->useSipHash = pfrom->xVersion.as_u64c(XVer::BU_GRAPHENE_VERSION_SUPPORTED) >= 2;
+
     if (inv.type == MSG_GRAPHENEBLOCK)
     {
         try

--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -32,7 +32,8 @@ CMemPoolInfo::CMemPoolInfo() { this->nTx = 0; }
 CGrapheneBlock::CGrapheneBlock(const CBlockRef pblock,
     uint64_t nReceiverMemPoolTx,
     uint64_t nSenderMempoolPlusBlock,
-    uint64_t _version)
+    uint64_t _version,
+    bool _computeOptimized)
     : // Use cryptographically strong pseudorandom number because
       // we will extract SipHash secret key from this
       sipHashNonce(GetRand(std::numeric_limits<uint64_t>::max())),
@@ -43,6 +44,7 @@ CGrapheneBlock::CGrapheneBlock(const CBlockRef pblock,
     uint64_t grapheneSetVersion = 0;
 
     version = _version;
+    computeOptimized = _computeOptimized;
     if (version >= 2)
         FillShortTxIDSelector();
 
@@ -50,8 +52,10 @@ CGrapheneBlock::CGrapheneBlock(const CBlockRef pblock,
         grapheneSetVersion = 0;
     if (version == 2)
         grapheneSetVersion = 1;
-    else if (version >= 3)
+    else if (version == 3)
         grapheneSetVersion = 2;
+    else if (version == 4)
+        grapheneSetVersion = 3;
 
     std::vector<uint256> blockHashes;
     for (auto &tx : pblock->vtx)
@@ -64,10 +68,10 @@ CGrapheneBlock::CGrapheneBlock(const CBlockRef pblock,
 
     if (enableCanonicalTxOrder.Value())
         pGrapheneSet = new CGrapheneSet(nReceiverMemPoolTx, nSenderMempoolPlusBlock, blockHashes, shorttxidk0,
-            shorttxidk1, grapheneSetVersion, (uint32_t)sipHashNonce, true, false);
+            shorttxidk1, grapheneSetVersion, (uint32_t)sipHashNonce, computeOptimized, false);
     else
         pGrapheneSet = new CGrapheneSet(nReceiverMemPoolTx, nSenderMempoolPlusBlock, blockHashes, shorttxidk0,
-            shorttxidk1, grapheneSetVersion, (uint32_t)sipHashNonce, true, true);
+            shorttxidk1, grapheneSetVersion, (uint32_t)sipHashNonce, computeOptimized, true);
 }
 
 CGrapheneBlock::~CGrapheneBlock()
@@ -1359,7 +1363,7 @@ void SendGrapheneBlock(CBlockRef pblock, CNode *pfrom, const CInv &inv, const CM
                 GetGrapheneMempoolInfo().nTx + pblock->vtx.size() - 1; // exclude coinbase
 
             CGrapheneBlock grapheneBlock(MakeBlockRef(*pblock), mempoolinfo.nTx, nSenderMempoolPlusBlock,
-                pfrom->xVersion.as_u64c(XVer::BU_GRAPHENE_VERSION_SUPPORTED));
+                pfrom->xVersion.as_u64c(XVer::BU_GRAPHENE_VERSION_SUPPORTED), computeOptimizeGraphene);
             pfrom->gr_shorttxidk0 = grapheneBlock.shorttxidk0;
             pfrom->gr_shorttxidk1 = grapheneBlock.shorttxidk1;
             int nSizeBlock = pblock->GetBlockSize();

--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -64,10 +64,10 @@ CGrapheneBlock::CGrapheneBlock(const CBlockRef pblock,
 
     if (enableCanonicalTxOrder.Value())
         pGrapheneSet = new CGrapheneSet(nReceiverMemPoolTx, nSenderMempoolPlusBlock, blockHashes, shorttxidk0,
-            shorttxidk1, grapheneSetVersion, (uint32_t)sipHashNonce, false);
+            shorttxidk1, grapheneSetVersion, (uint32_t)sipHashNonce, true, false);
     else
         pGrapheneSet = new CGrapheneSet(nReceiverMemPoolTx, nSenderMempoolPlusBlock, blockHashes, shorttxidk0,
-            shorttxidk1, grapheneSetVersion, (uint32_t)sipHashNonce, true);
+            shorttxidk1, grapheneSetVersion, (uint32_t)sipHashNonce, true, true);
 }
 
 CGrapheneBlock::~CGrapheneBlock()

--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -53,13 +53,6 @@ CGrapheneBlock::CGrapheneBlock(const CBlockRef pblock,
     else if (version >= 3)
         grapheneSetVersion = 2;
 
-    version = _version;
-    if (version >= 2)
-    {
-        FillShortTxIDSelector();
-        grapheneSetVersion = 1;
-    }
-
     std::vector<uint256> blockHashes;
     for (auto &tx : pblock->vtx)
     {

--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -1529,7 +1529,8 @@ uint64_t GetShortID(uint64_t shorttxidk0, uint64_t shorttxidk1, const uint256 &t
 }
 
 // Generate cheap hash from seeds using SipHash
-uint64_t GetShortID(uint64_t shorttxidk0, uint64_t shorttxidk1, const uint256& txhash, bool useSipHash) {
+uint64_t GetShortID(uint64_t shorttxidk0, uint64_t shorttxidk1, const uint256 &txhash, bool useSipHash)
+{
     if (!useSipHash)
         return txhash.GetCheapHash();
 

--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -1528,13 +1528,3 @@ uint64_t GetShortID(uint64_t shorttxidk0, uint64_t shorttxidk1, const uint256 &t
     static_assert(SHORTTXIDS_LENGTH == 8, "shorttxids calculation assumes 8-byte shorttxids");
     return SipHashUint256(shorttxidk0, shorttxidk1, txhash) & 0xffffffffffffffL;
 }
-
-// Generate cheap hash from seeds using SipHash
-uint64_t GetShortID(uint64_t shorttxidk0, uint64_t shorttxidk1, const uint256 &txhash, uint64_t grapheneVersion)
-{
-    if (grapheneVersion < 2)
-        return txhash.GetCheapHash();
-
-    static_assert(SHORTTXIDS_LENGTH == 8, "shorttxids calculation assumes 8-byte shorttxids");
-    return SipHashUint256(shorttxidk0, shorttxidk1, txhash) & 0xffffffffffffffL;
-}

--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -56,6 +56,8 @@ CGrapheneBlock::CGrapheneBlock(const CBlockRef pblock,
         grapheneSetVersion = 2;
     else if (version == 4)
         grapheneSetVersion = 3;
+    else if (version == 5)
+        grapheneSetVersion = 4;
 
     std::vector<uint256> blockHashes;
     for (auto &tx : pblock->vtx)

--- a/src/blockrelay/graphene.h
+++ b/src/blockrelay/graphene.h
@@ -103,7 +103,9 @@ public:
             throw std::runtime_error("nBlockTxs exceeds threshold for excessive block txs");
         if (!pGrapheneSet)
         {
-            if (version > 2)
+            if (version > 3)
+                pGrapheneSet = new CGrapheneSet(3);
+            else if (version == 3)
                 pGrapheneSet = new CGrapheneSet(2);
             else if (version == 2)
                 pGrapheneSet = new CGrapheneSet(1);

--- a/src/blockrelay/graphene.h
+++ b/src/blockrelay/graphene.h
@@ -60,14 +60,16 @@ public:
     uint64_t nBlockTxs;
     CGrapheneSet *pGrapheneSet;
     uint64_t version;
+    bool computeOptimized;
 
 public:
     CGrapheneBlock(const CBlockRef pblock,
         uint64_t nReceiverMemPoolTx,
         uint64_t nSenderMempoolPlusBlock,
-        uint64_t _version);
-    CGrapheneBlock() : shorttxidk0(0), shorttxidk1(0), pGrapheneSet(nullptr), version(2) {}
-    CGrapheneBlock(uint64_t _version) : shorttxidk0(0), shorttxidk1(0), pGrapheneSet(nullptr) { version = _version; }
+        uint64_t _version,
+        bool _computeOptimized);
+    CGrapheneBlock() : shorttxidk0(0), shorttxidk1(0), pGrapheneSet(nullptr), version(2), computeOptimized(false) {}
+    CGrapheneBlock(uint64_t _version) : shorttxidk0(0), shorttxidk1(0), pGrapheneSet(nullptr), computeOptimized(false) { version = _version; }
     ~CGrapheneBlock();
     // Create seeds for SipHash using the sipHashNonce generated in the constructor
     // Note that this must be called any time members header or sipHashNonce are changed

--- a/src/blockrelay/graphene.h
+++ b/src/blockrelay/graphene.h
@@ -69,7 +69,10 @@ public:
         uint64_t _version,
         bool _computeOptimized);
     CGrapheneBlock() : shorttxidk0(0), shorttxidk1(0), pGrapheneSet(nullptr), version(2), computeOptimized(false) {}
-    CGrapheneBlock(uint64_t _version) : shorttxidk0(0), shorttxidk1(0), pGrapheneSet(nullptr), computeOptimized(false) { version = _version; }
+    CGrapheneBlock(uint64_t _version) : shorttxidk0(0), shorttxidk1(0), pGrapheneSet(nullptr), computeOptimized(false)
+    {
+        version = _version;
+    }
     ~CGrapheneBlock();
     // Create seeds for SipHash using the sipHashNonce generated in the constructor
     // Note that this must be called any time members header or sipHashNonce are changed

--- a/src/blockrelay/graphene.h
+++ b/src/blockrelay/graphene.h
@@ -108,7 +108,9 @@ public:
             throw std::runtime_error("nBlockTxs exceeds threshold for excessive block txs");
         if (!pGrapheneSet)
         {
-            if (version > 3)
+            if (version > 4)
+                pGrapheneSet = new CGrapheneSet(4);
+            else if (version == 4)
                 pGrapheneSet = new CGrapheneSet(3);
             else if (version == 3)
                 pGrapheneSet = new CGrapheneSet(2);

--- a/src/blockrelay/graphene_set.cpp
+++ b/src/blockrelay/graphene_set.cpp
@@ -21,6 +21,7 @@ CGrapheneSet::CGrapheneSet(size_t _nReceiverUniverseItems,
     uint64_t _shorttxidk1,
     uint64_t _version,
     uint32_t ibltEntropy,
+    bool _computeOptimized,
     bool _ordered,
     bool fDeterministic)
 {
@@ -33,6 +34,7 @@ CGrapheneSet::CGrapheneSet(size_t _nReceiverUniverseItems,
     shorttxidk1 = _shorttxidk1;
     ibltSalt = ibltEntropy;
     version = _version;
+    computeOptimized = _computeOptimized;
 
     // Below is the parameter "n" from the graphene paper
     uint64_t nItems = _itemHashes.size();
@@ -75,8 +77,15 @@ CGrapheneSet::CGrapheneSet(size_t _nReceiverUniverseItems,
     optSymDiff += nReceiverMissingItems;
 
     // Construct Bloom filter
-    pSetFilter = new CBloomFilter(
-        nItems, fpr, insecure_rand.rand32(), BLOOM_UPDATE_ALL, true, std::numeric_limits<uint32_t>::max());
+    if (computeOptimized)
+    {
+        pFastFilter = new CVariableFastFilter(4, nextPowerOfTwo((int)std::max(2, (int)nItems)));
+    }
+    else
+    {
+        pSetFilter = new CBloomFilter(
+            nItems, fpr, insecure_rand.rand32(), BLOOM_UPDATE_ALL, true, std::numeric_limits<uint32_t>::max());
+    }
     LOG(GRAPHENE, "fp rate: %f Num elements in bloom filter: %d\n", fpr, nItems);
 
     // Construct IBLT
@@ -90,7 +99,14 @@ CGrapheneSet::CGrapheneSet(size_t _nReceiverUniverseItems,
     {
         uint64_t cheapHash = GetShortID(itemHash);
 
-        pSetFilter->insert(itemHash);
+        if (computeOptimized)
+        {
+            pFastFilter->insert(itemHash);
+        }
+        else
+        {
+            pSetFilter->insert(itemHash);
+        }
 
         if (mapCheapHashes.count(cheapHash))
             throw std::runtime_error("Cheap hash collision while encoding graphene set");
@@ -242,7 +258,8 @@ std::vector<uint64_t> CGrapheneSet::Reconcile(const std::vector<uint256> &receiv
             throw std::runtime_error("Cheap hash collision while decoding graphene set");
         }
 
-        if ((*pSetFilter).contains(itemHash))
+        if ((computeOptimized && (*pFastFilter).contains(itemHash)) ||
+            (!computeOptimized && (*pSetFilter).contains(itemHash)))
         {
             receiverSet.insert(cheapHash);
             localIblt.insert(cheapHash, IBLT_NULL_VALUE);
@@ -265,7 +282,8 @@ std::vector<uint64_t> CGrapheneSet::Reconcile(const std::map<uint64_t, uint256> 
 
     for (const auto &entry : mapCheapHashes)
     {
-        if ((*pSetFilter).contains(entry.second))
+        if ((computeOptimized && (*pFastFilter).contains(entry.second)) ||
+            (!computeOptimized && (*pSetFilter).contains(entry.second)))
         {
             receiverSet.insert(entry.first);
             localIblt.insert(entry.first, IBLT_NULL_VALUE);
@@ -362,4 +380,18 @@ std::vector<uint64_t> CGrapheneSet::DecodeRank(std::vector<unsigned char> encode
             items[i] |= bits[j + i * nBitsPerItem] << j;
     }
     return items;
+}
+
+uint64_t nextPowerOfTwo(uint64_t n)
+{
+    --n;
+
+    n |= n >> 1;
+    n |= n >> 2;
+    n |= n >> 4;
+    n |= n >> 8;
+    n |= n >> 16;
+    n |= n >> 32;
+
+    return n + 1;
 }

--- a/src/blockrelay/graphene_set.cpp
+++ b/src/blockrelay/graphene_set.cpp
@@ -79,7 +79,7 @@ CGrapheneSet::CGrapheneSet(size_t _nReceiverUniverseItems,
     // Construct Bloom filter
     if (computeOptimized)
     {
-        pFastFilter = new CVariableFastFilter(4, nextPowerOfTwo((int)std::max(2, (int)nItems)));
+        pFastFilter = new CVariableFastFilter(nItems, fpr);
     }
     else
     {
@@ -380,18 +380,4 @@ std::vector<uint64_t> CGrapheneSet::DecodeRank(std::vector<unsigned char> encode
             items[i] |= bits[j + i * nBitsPerItem] << j;
     }
     return items;
-}
-
-uint64_t nextPowerOfTwo(uint64_t n)
-{
-    --n;
-
-    n |= n >> 1;
-    n |= n >> 2;
-    n |= n >> 4;
-    n |= n >> 8;
-    n |= n >> 16;
-    n |= n >> 32;
-
-    return n + 1;
 }

--- a/src/blockrelay/graphene_set.h
+++ b/src/blockrelay/graphene_set.h
@@ -33,7 +33,6 @@ const float IBLT_DEFAULT_OVERHEAD = 1.5;
 class CGrapheneSet
 {
 private:
-    mutable uint64_t shorttxidk0, shorttxidk1;
     bool ordered;
     uint64_t nReceiverUniverseItems;
     mutable uint64_t shorttxidk0, shorttxidk1;
@@ -163,8 +162,6 @@ public:
             READWRITE(ibltSalt);
         if (nReceiverUniverseItems > LARGE_MEM_POOL_SIZE)
             throw std::runtime_error("nReceiverUniverseItems exceeds threshold for excessive mempool size");
-        READWRITE(shorttxidk0);
-        READWRITE(shorttxidk1);
         READWRITE(encodedRank);
         if (!pSetFilter)
             pSetFilter = new CBloomFilter();

--- a/src/blockrelay/graphene_set.h
+++ b/src/blockrelay/graphene_set.h
@@ -200,6 +200,4 @@ public:
     }
 };
 
-uint64_t nextPowerOfTwo(uint64_t n);
-
 #endif // BITCOIN_GRAPHENE_SET_H

--- a/src/blockrelay/graphene_set.h
+++ b/src/blockrelay/graphene_set.h
@@ -132,12 +132,23 @@ public:
 
     static std::vector<uint64_t> DecodeRank(std::vector<unsigned char> encoded, size_t nItems, uint16_t nBitsPerItem);
 
-    uint64_t GetFilterSerializationSize() { return ::GetSerializeSize(*pSetFilter, SER_NETWORK, PROTOCOL_VERSION); }
+    uint64_t GetFilterSerializationSize() { 
+        if (computeOptimized)
+            return ::GetSerializeSize(*pFastFilter, SER_NETWORK, PROTOCOL_VERSION); 
+        else
+            return ::GetSerializeSize(*pSetFilter, SER_NETWORK, PROTOCOL_VERSION); 
+    }
     uint64_t GetIbltSerializationSize() { return ::GetSerializeSize(*pSetIblt, SER_NETWORK, PROTOCOL_VERSION); }
     uint64_t GetRankSerializationSize() { return ::GetSerializeSize(encodedRank, SER_NETWORK, PROTOCOL_VERSION); }
     ~CGrapheneSet()
     {
-        if (pSetFilter)
+        if (computeOptimized && pFastFilter)
+        {
+            delete pFastFilter;
+            pFastFilter = nullptr;
+        }
+
+        if (!computeOptimized && pSetFilter)
         {
             delete pSetFilter;
             pSetFilter = nullptr;

--- a/src/blockrelay/graphene_set.h
+++ b/src/blockrelay/graphene_set.h
@@ -33,6 +33,7 @@ const float IBLT_DEFAULT_OVERHEAD = 1.5;
 class CGrapheneSet
 {
 private:
+    mutable uint64_t shorttxidk0, shorttxidk1;
     bool ordered;
     uint64_t nReceiverUniverseItems;
     mutable uint64_t shorttxidk0, shorttxidk1;
@@ -162,6 +163,8 @@ public:
             READWRITE(ibltSalt);
         if (nReceiverUniverseItems > LARGE_MEM_POOL_SIZE)
             throw std::runtime_error("nReceiverUniverseItems exceeds threshold for excessive mempool size");
+        READWRITE(shorttxidk0);
+        READWRITE(shorttxidk1);
         READWRITE(encodedRank);
         if (!pSetFilter)
             pSetFilter = new CBloomFilter();

--- a/src/blockrelay/graphene_set.h
+++ b/src/blockrelay/graphene_set.h
@@ -6,6 +6,7 @@
 #define BITCOIN_GRAPHENE_SET_H
 
 #include "bloom.h"
+#include "fastfilter.h"
 #include "hash.h"
 #include "iblt.h"
 #include "random.h"
@@ -38,8 +39,10 @@ private:
     mutable uint64_t shorttxidk0, shorttxidk1;
     uint64_t version;
     uint32_t ibltSalt;
+    bool computeOptimized;
     std::vector<unsigned char> encodedRank;
     CBloomFilter *pSetFilter;
+    CVariableFastFilter *pFastFilter;
     CIblt *pSetIblt;
 
     static const uint8_t SHORTTXIDS_LENGTH = 8;
@@ -58,12 +61,12 @@ public:
     // The default constructor is for 2-phase construction via deserialization
     CGrapheneSet()
         : ordered(false), nReceiverUniverseItems(0), shorttxidk0(0), shorttxidk1(0), version(1), ibltSalt(0),
-          pSetFilter(nullptr), pSetIblt(nullptr)
+          computeOptimized(false), pSetFilter(nullptr), pFastFilter(nullptr), pSetIblt(nullptr)
     {
     }
     CGrapheneSet(uint64_t _version)
-        : ordered(false), nReceiverUniverseItems(0), shorttxidk0(0), shorttxidk1(0), ibltSalt(0), pSetFilter(nullptr),
-          pSetIblt(nullptr)
+        : ordered(false), nReceiverUniverseItems(0), shorttxidk0(0), shorttxidk1(0), ibltSalt(0),
+          computeOptimized(false), pSetFilter(nullptr), pFastFilter(nullptr), pSetIblt(nullptr)
     {
         version = _version;
     }
@@ -74,6 +77,7 @@ public:
         uint64_t _shorttxidk1,
         uint64_t _version = 1,
         uint32_t ibltEntropy = 0,
+        bool _computeOptimized = false,
         bool _ordered = false,
         bool fDeterministic = false);
 
@@ -153,6 +157,8 @@ public:
     {
         READWRITE(ordered);
         READWRITE(nReceiverUniverseItems);
+        if (nReceiverUniverseItems > LARGE_MEM_POOL_SIZE)
+            throw std::runtime_error("nReceiverUniverseItems exceeds threshold for excessive mempool size");
         if (version > 0)
         {
             READWRITE(shorttxidk0);
@@ -160,16 +166,29 @@ public:
         }
         if (version >= 2)
             READWRITE(ibltSalt);
-        if (nReceiverUniverseItems > LARGE_MEM_POOL_SIZE)
-            throw std::runtime_error("nReceiverUniverseItems exceeds threshold for excessive mempool size");
+        if (version >= 3)
+            READWRITE(computeOptimized);
         READWRITE(encodedRank);
-        if (!pSetFilter)
-            pSetFilter = new CBloomFilter();
-        READWRITE(*pSetFilter);
+        if (version >= 3 && computeOptimized)
+        {
+            if (!pFastFilter)
+                pFastFilter = new CVariableFastFilter();
+
+            READWRITE(*pFastFilter);
+        }
+        else
+        {
+            if (!pSetFilter)
+                pSetFilter = new CBloomFilter();
+
+            READWRITE(*pSetFilter);
+        }
         if (!pSetIblt)
             pSetIblt = new CIblt();
         READWRITE(*pSetIblt);
     }
 };
+
+uint64_t nextPowerOfTwo(uint64_t n);
 
 #endif // BITCOIN_GRAPHENE_SET_H

--- a/src/blockrelay/graphene_set.h
+++ b/src/blockrelay/graphene_set.h
@@ -132,11 +132,12 @@ public:
 
     static std::vector<uint64_t> DecodeRank(std::vector<unsigned char> encoded, size_t nItems, uint16_t nBitsPerItem);
 
-    uint64_t GetFilterSerializationSize() { 
+    uint64_t GetFilterSerializationSize()
+    {
         if (computeOptimized)
-            return ::GetSerializeSize(*pFastFilter, SER_NETWORK, PROTOCOL_VERSION); 
+            return ::GetSerializeSize(*pFastFilter, SER_NETWORK, PROTOCOL_VERSION);
         else
-            return ::GetSerializeSize(*pSetFilter, SER_NETWORK, PROTOCOL_VERSION); 
+            return ::GetSerializeSize(*pSetFilter, SER_NETWORK, PROTOCOL_VERSION);
     }
     uint64_t GetIbltSerializationSize() { return ::GetSerializeSize(*pSetIblt, SER_NETWORK, PROTOCOL_VERSION); }
     uint64_t GetRankSerializationSize() { return ::GetSerializeSize(encodedRank, SER_NETWORK, PROTOCOL_VERSION); }

--- a/src/fastfilter.h
+++ b/src/fastfilter.h
@@ -60,7 +60,7 @@ public:
         nFilterItems = _nFilterItems;
 
         assert((nHashFuncs > 1) && (nHashFuncs <= 32));
-        assert(isPow2(nFilterItems) && (nFilterItems > 1));
+        assert(nFilterItems > 1);
 
         FastRandomContext insecure_rand;
         vData.resize(std::max(1, (int)std::ceil(nFilterItems / 8)));

--- a/src/fastfilter.h
+++ b/src/fastfilter.h
@@ -8,8 +8,10 @@
 #include "random.h"
 #include "serialize.h"
 #include "util.h"
+#include <cmath>
 #include <vector>
 
+const uint32_t MAX_32_BIT = (int)pow(2, 32) - 1;
 class uint256;
 
 // Statically evaluated expression to return whether a number is a power of 2
@@ -50,7 +52,7 @@ protected:
 
 public:
     uint8_t nHashFuncs;
-    uint64_t nFilterItems;
+    uint32_t nFilterItems;
 
     CVariableFastFilter() : nHashFuncs(2), nFilterItems(2){};
 
@@ -60,7 +62,7 @@ public:
         nFilterItems = _nFilterItems;
 
         assert((nHashFuncs > 1) && (nHashFuncs <= 32));
-        assert(nFilterItems > 1);
+        assert((nFilterItems > 1) && (nFilterItems <= MAX_32_BIT));
 
         FastRandomContext insecure_rand;
         vData.resize(std::max(1, (int)std::ceil(nFilterItems / 8)));

--- a/src/fastfilter.h
+++ b/src/fastfilter.h
@@ -14,33 +14,11 @@
 const uint32_t MAX_32_BIT = (int)pow(2, 32) - 1;
 class uint256;
 
-// Statically evaluated expression to return whether a number is a power of 2
-constexpr bool isPow2(unsigned int num) { return num && !(num & (num - 1)); }
 /**
- * FastFilter is a probabilistic filter.  The filter can answer whether an element
- * definitely is NOT in the set, but only that an element is LIKELY in the set.
- * This is similar to a Bloom filter, but much faster.
- *
- * This filter expects that the input elements have a random distribution (i.e. hashes), and so does not hash the
- * input again.  This is how it gains the majority of its performance improvement.
- *
  * This class can be used anywhere a Bloom filter is used so long as the input data is random.
  *
  * If nHashFuncs is 16 and nFilterItems is >= 64k all bits in the uint256 input data will be used to set bits in
- * the filter.  If these fields are set to lower numbers, fewer bits may be used (although in the nHashFuncs case
- * execution will be faster).  Therefore, if this structure is used in an application that accepts externally created
- * uint256 numbers that are sensitive to deliberately constructed collisions, be sure to keep nHashFuncs high enough
- * that the creation of collisions in the used bits is not feasible.
- *
- * Note also that the input bits are used without obfuscation or mixing so if an attacker can control some input bits
- * the attacker can cause collisions in some of the fast filter entries for his inputs.  This will cause higher false
- * positive rates for these transactions.  For example, if the attacker can control 32 bits of the input, he can
- * effectively reduce the number of hash functions in the fast filter by 2 because he has engineered a guaranteed
- * collision for the two functions that use those bits.
- *
- * This class is thread-safe in the sense that simultaneous calls to member functions will not crash,
- * but "inserts" may be lost.  However, if you are using this class as an in-ram filter before doing a more expensive
- * operation, a lost insert may be acceptable.
+ * the filter.   
  *
  * nHashFuncs may range from 2 to 32 inclusive.
  */
@@ -124,10 +102,44 @@ public:
     }
 };
 
-
+// Statically evaluated expression to return whether a number is a power of 2
+constexpr bool isPow2(unsigned int num) { return num && !(num & (num - 1)); }
+/**
+ * FastFilter is a probabilistic filter.  The filter can answer whether an element
+ * definitely is NOT in the set, but only that an element is LIKELY in the set.
+ * This is similar to a Bloom filter, but much faster.
+ *
+ * This filter expects that the input elements have a random distribution (i.e. hashes), and so does not hash the
+ * input again.  This is how it gains the majority of its performance improvement.
+ *
+ * This class can be used anywhere a Bloom filter is used so long as the input data is random.
+ *
+ * If NUM_HASH_FNS is 16 and FILTER_SIZE is >= 64k all bits in the uint256 input data will be used to set bits in
+ * the filter.  If these fields are set to lower numbers, fewer bits may be used (although in the NUM_HASH_FNS case
+ * execution will be faster).  Therefore, if this structure is used in an application that accepts externally created
+ * uint256 numbers that are sensitive to deliberately constructed collisions, be sure to keep NUM_HASH_FNS high enough
+ * that the creation of collisions in the used bits is not feasible.
+ *
+ * Note also that the input bits are used without obfuscation or mixing so if an attacker can control some input bits
+ * the attacker can cause collisions in some of the fast filter entries for his inputs.  This will cause higher false
+ * positive rates for these transactions.  For example, if the attacker can control 32 bits of the input, he can
+ * effectively reduce the number of hash functions in the fast filter by 2 because he has engineered a guaranteed
+ * collision for the two functions that use those bits.
+ *
+ * This class is thread-safe in the sense that simultaneous calls to member functions will not crash,
+ * but "inserts" may be lost.  However, if you are using this class as an in-ram filter before doing a more expensive
+ * operation, a lost insert may be acceptable.
+ *
+ * FILTER_SIZE must be a power of 2, and NUM_HASH_FNS may range from 2 to 16 inclusive.  Since hashes are calculated
+ * in pairs of 2, odd values of NUM_HASH_FNS are rounded down.
+ */
 template <unsigned int FILTER_SIZE, unsigned int NUM_HASH_FNS = 16>
-class CFastFilter : public CVariableFastFilter
+class CFastFilter
 {
+protected:
+    // A bit vector containing the bloom filter data
+    std::vector<unsigned char> vData;
+
 public:
     enum
     {
@@ -138,12 +150,70 @@ public:
     {
         static_assert((NUM_HASH_FNS > 1) && (NUM_HASH_FNS <= 16), "NUM_HASH_FNS must be between 2 and 16 inclusive");
         static_assert(isPow2(FILTER_SIZE) && (FILTER_SIZE > 1), "FILTER_SIZE must be a power of 2 greater than 1");
-        nHashFuncs = NUM_HASH_FNS;
-        nFilterItems = FILTER_SIZE;
-
         FastRandomContext insecure_rand;
         vData.resize(FILTER_BYTES);
     }
+
+
+    // returns true IF this function made a change (i.e. the value was previously not set).
+    bool checkAndSet(const uint256 &hash)
+    {
+        const uint32_t *pos = (const uint32_t *)hash.begin();
+        bool unset = 0; // If any position is not set, then this will be true
+        for (unsigned int i = 0; i < NUM_HASH_FNS / 2; i++, pos++)
+        {
+            uint32_t val = *pos;
+            uint32_t idx = val & (FILTER_SIZE - 1);
+            uint32_t bit = (1 << (idx & 7));
+            idx >>= 3;
+            unset |= (0 == (vData[idx] & bit));
+
+            val = __builtin_bswap32(val);
+            uint32_t idx2 = val & (FILTER_SIZE - 1);
+            uint32_t bit2 = (1 << (idx2 & 7));
+            idx2 >>= 3;
+
+            unset |= (0 == (vData[idx2] & bit2));
+
+            vData[idx] |= bit;
+            vData[idx2] |= bit2;
+        }
+        return unset;
+    }
+
+    void insert(const uint256 &hash)
+    {
+        const uint32_t *pos = (const uint32_t *)hash.begin();
+        for (unsigned int i = 0; i < NUM_HASH_FNS / 2; i++, pos++)
+        {
+            uint32_t val = *pos;
+            uint32_t idx = val & (FILTER_SIZE - 1);
+            val = __builtin_bswap32(val);
+            uint32_t idx2 = val & (FILTER_SIZE - 1);
+
+            vData[idx >> 3] |= (1 << (idx & 7));
+            vData[idx2 >> 3] |= (1 << (idx2 & 7));
+        }
+    }
+
+    bool contains(const uint256 &hash) const
+    {
+        const uint32_t *pos = (const uint32_t *)hash.begin();
+        bool unset = 0; // If any position is not set, then this will be true
+        for (unsigned int i = 0; i < NUM_HASH_FNS / 2; i++, pos++)
+        {
+            uint32_t val = *pos;
+            uint32_t idx = val & (FILTER_SIZE - 1);
+            val = __builtin_bswap32(val);
+            uint32_t idx2 = val & (FILTER_SIZE - 1);
+
+            unset |= (0 == (vData[idx >> 3] & (1 << (idx & 7))));
+            unset |= (0 == (vData[idx2 >> 3] & (1 << (idx2 & 7))));
+        }
+        return !unset;
+    }
+
+    void reset() { memset(&vData[0], 0, FILTER_BYTES); }
 };
 
 

--- a/src/iblt.cpp
+++ b/src/iblt.cpp
@@ -372,3 +372,394 @@ uint8_t CIblt::MaxNHash()
 
     return maxHashes;
 }
+
+
+/******** version > 1 *********/
+
+
+static inline uint32_t keyChecksumCalcNoCheck(const std::vector<uint8_t> &kvec, uint32_t checksumSpace)
+{
+    return MurmurHash3(N_HASHCHECK, kvec) % checksumSpace;
+}
+
+bool HashTableEntryNoCheck::isPure(uint32_t checksum, uint32_t checksumSpace) const
+{
+    if (count == 1 || count == -1)
+    {
+        uint32_t check = keyChecksumCalcNoCheck(ToVec(keySum), checksumSpace);
+        return (checksum == check);
+    }
+    return false;
+}
+
+bool HashTableEntryNoCheck::empty(uint32_t checksum) const { 
+    return (count == 0 && keySum == 0 && checksum == 0); 
+}
+
+void HashTableEntryNoCheck::addValue(const std::vector<uint8_t> &v)
+{
+    if (v.empty())
+    {
+        return;
+    }
+    if (valueSum.size() < v.size())
+    {
+        valueSum.resize(v.size());
+    }
+    for (size_t i = 0; i < v.size(); i++)
+    {
+        valueSum[i] ^= v[i];
+    }
+}
+
+CIbltNoCheck::CIbltNoCheck()
+{
+    salt = 0;
+    n_hash = 1;
+    is_modified = false;
+    version = 2;
+    nChecksumBits = 32;
+}
+
+CIbltNoCheck::CIbltNoCheck(uint64_t _version)
+{
+    salt = 0;
+    n_hash = 1;
+    is_modified = false;
+    nChecksumBits = 32;
+
+    CIbltNoCheck::version = _version;
+
+    if (CIbltNoCheck::version < 2)
+        throw std::ios_base::failure("CIbltNoCheck version must exceed version 1");
+}
+
+CIbltNoCheck::CIbltNoCheck(size_t _expectedNumEntries, uint64_t _version) : n_hash(0), is_modified(false), salt(0), nChecksumBits(32)
+{
+    CIbltNoCheck::version = _version;
+    CIbltNoCheck::resize(_expectedNumEntries);
+
+    if (CIbltNoCheck::version < 2)
+        throw std::ios_base::failure("CIbltNoCheck version must exceed version 1");
+}
+
+CIbltNoCheck::CIbltNoCheck(size_t _expectedNumEntries, uint32_t _salt, uint64_t _version) : n_hash(0), is_modified(false), nChecksumBits(32)
+{
+    CIbltNoCheck::version = _version;
+    CIbltNoCheck::salt = _salt;
+    CIbltNoCheck::resize(_expectedNumEntries);
+
+    if (CIbltNoCheck::version < 2)
+        throw std::ios_base::failure("CIbltNoCheck version must exceed version 1");
+}
+
+CIbltNoCheck::CIbltNoCheck(size_t _expectedNumEntries, uint32_t _salt, uint64_t _version, uint8_t _nChecksumBits) : n_hash(0), is_modified(false)
+{
+    CIbltNoCheck::version = _version;
+    CIbltNoCheck::salt = _salt;
+    CIbltNoCheck::nChecksumBits = _nChecksumBits;
+    CIbltNoCheck::resize(_expectedNumEntries);
+
+    if (CIbltNoCheck::version < 2)
+        throw std::ios_base::failure("CIbltNoCheck version must exceed version 1");
+}
+
+CIbltNoCheck::CIbltNoCheck(const CIbltNoCheck &other) : n_hash(0), is_modified(false)
+{
+    salt = other.salt;
+    version = other.version;
+    n_hash = other.n_hash;
+    hashTable = other.hashTable;
+    nChecksumBits = other.nChecksumBits;
+    vChecksums = other.vChecksums;
+    mapHashIdxSeeds = other.mapHashIdxSeeds;
+
+    if (version < 2)
+        throw std::ios_base::failure("CIbltNoCheck version must exceed version 1");
+}
+
+CIbltNoCheck::~CIbltNoCheck() {}
+void CIbltNoCheck::reset()
+{
+    size_t size = this->size();
+    hashTable.clear();
+    hashTable.resize(size);
+    vChecksums.clear();
+    vChecksums.resize(nChecksumBits*size, false);
+    is_modified = false;
+}
+
+uint64_t CIbltNoCheck::size() { return hashTable.size(); }
+void CIbltNoCheck::resize(size_t _expectedNumEntries)
+{
+    assert(is_modified == false);
+
+    CIbltNoCheck::n_hash = OptimalNHash(_expectedNumEntries);
+
+    // set hash seeds from salt
+    for (size_t i = 0; i < n_hash; i++)
+        mapHashIdxSeeds[i] = salt % (0xffffffff - n_hash) + i;
+
+    // reduce probability of failure by increasing by overhead factor
+    size_t nEntries = (size_t)(_expectedNumEntries * OptimalOverhead(_expectedNumEntries));
+    // ... make nEntries exactly divisible by n_hash
+    while (n_hash * (nEntries / n_hash) != nEntries)
+        ++nEntries;
+    hashTable.resize(nEntries);
+
+    vChecksums.resize(nEntries * nChecksumBits, false);
+}
+
+uint32_t CIbltNoCheck::saltedHashValue(size_t hashFuncIdx, const std::vector<uint8_t> &kvec) const
+{
+    if (version > 0)
+    {
+        uint32_t seed = mapHashIdxSeeds.at(hashFuncIdx);
+        return MurmurHash3(seed, kvec);
+    }
+    else
+        return MurmurHash3(hashFuncIdx, kvec);
+}
+
+void CIbltNoCheck::_insert(int plusOrMinus, uint64_t k, const std::vector<uint8_t> &v)
+{
+    if (!n_hash)
+        return;
+    size_t bucketsPerHash = hashTable.size() / n_hash;
+    if (!bucketsPerHash)
+        return;
+
+    std::vector<uint8_t> kvec = ToVec(k);
+    uint32_t checksumSpace = (int) std::pow(2, nChecksumBits);
+    const uint32_t kchk = keyChecksumCalcNoCheck(kvec, checksumSpace);
+
+    for (size_t i = 0; i < n_hash; i++)
+    {
+        size_t startEntry = i * bucketsPerHash;
+
+        uint32_t h = saltedHashValue(i, kvec);
+        size_t entryIdx = startEntry + (h % bucketsPerHash);
+        HashTableEntryNoCheck &entry = hashTable.at(entryIdx);
+        entry.count += plusOrMinus;
+        entry.keySum ^= k;
+        uint32_t checksum = readChecksum(entryIdx);
+        checksum ^= kchk;
+        writeChecksum(entryIdx, checksum);
+        if (entry.empty(checksum))
+        {
+            entry.valueSum.clear();
+        }
+        else
+        {
+            entry.addValue(v);
+        }
+    }
+
+    is_modified = true;
+}
+
+void CIbltNoCheck::insert(uint64_t k, const std::vector<uint8_t> &v) { _insert(1, k, v); }
+void CIbltNoCheck::erase(uint64_t k, const std::vector<uint8_t> &v) { _insert(-1, k, v); }
+bool CIbltNoCheck::get(uint64_t k, std::vector<uint8_t> &result) const
+{
+    result.clear();
+    uint32_t checksumSpace = (int) std::pow(2, nChecksumBits);
+
+    if (!n_hash)
+        return false;
+    size_t bucketsPerHash = hashTable.size() / n_hash;
+    if (!bucketsPerHash)
+        return false;
+
+    std::vector<uint8_t> kvec = ToVec(k);
+
+    for (size_t i = 0; i < n_hash; i++)
+    {
+        size_t startEntry = i * bucketsPerHash;
+
+        uint32_t h = saltedHashValue(i, kvec);
+        size_t entryIdx = startEntry + (h % bucketsPerHash);
+        const HashTableEntryNoCheck &entry = hashTable.at(entryIdx);
+        uint32_t checksum = readChecksum(entryIdx);
+
+        if (entry.empty(checksum))
+        {
+            // Definitely not in table. Leave
+            // result empty, return true.
+            return true;
+        }
+        else if (entry.isPure(checksum, checksumSpace))
+        {
+            if (entry.keySum == k)
+            {
+                // Found!
+                result.assign(entry.valueSum.begin(), entry.valueSum.end());
+                return true;
+            }
+            else
+            {
+                // Definitely not in table.
+                return true;
+            }
+        }
+    }
+
+    // Don't know if k is in table or not; "peel" the IBLT to try to find
+    // it:
+    CIbltNoCheck peeled = *this;
+    size_t nErased = 0;
+    for (size_t i = 0; i < peeled.hashTable.size(); i++)
+    {
+        HashTableEntryNoCheck &entry = peeled.hashTable.at(i);
+        uint32_t checksum = readChecksum(i);
+        if (entry.isPure(checksum, checksumSpace))
+        {
+            if (entry.keySum == k)
+            {
+                // Found!
+                result.assign(entry.valueSum.begin(), entry.valueSum.end());
+                return true;
+            }
+            ++nErased;
+            // NOTE: Need to create a copy of valueSum here as entry is just a reference!
+            std::vector<uint8_t> vec = entry.valueSum;
+            peeled._insert(-entry.count, entry.keySum, vec);
+        }
+    }
+    if (nErased > 0)
+    {
+        // Recurse with smaller IBLT
+        return peeled.get(k, result);
+    }
+    return false;
+}
+
+bool CIbltNoCheck::listEntries(std::set<std::pair<uint64_t, std::vector<uint8_t> > > &positive,
+    std::set<std::pair<uint64_t, std::vector<uint8_t> > > &negative) const
+{
+    CIbltNoCheck peeled = *this;
+    uint32_t checksumSpace = (int) std::pow(2, nChecksumBits);
+
+    size_t nErased = 0;
+    size_t nTotalErased = 0;
+    do
+    {
+        nErased = 0;
+        for (size_t i = 0; i < peeled.hashTable.size(); i++)
+        {
+            HashTableEntryNoCheck &entry = peeled.hashTable.at(i);
+            uint32_t checksum = peeled.readChecksum(i);
+            if (entry.isPure(checksum, checksumSpace))
+            {
+                if (entry.count == 1)
+                {
+                    positive.insert(std::make_pair(entry.keySum, entry.valueSum));
+                }
+                else
+                {
+                    negative.insert(std::make_pair(entry.keySum, entry.valueSum));
+                }
+                // NOTE: Need to create a copy of valueSum here as entry is just a reference!
+                std::vector<uint8_t> vec = entry.valueSum;
+                peeled._insert(-entry.count, entry.keySum, vec);
+                ++nErased;
+            }
+        }
+        nTotalErased += nErased;
+    } while (nErased > 0 && nTotalErased < peeled.hashTable.size() / MIN_OVERHEAD);
+
+    if (!n_hash)
+        return false;
+    size_t peeled_bucketsPerHash = peeled.hashTable.size() / n_hash;
+    if (!peeled_bucketsPerHash)
+        return false;
+
+    // If any buckets for one of the hash functions is not empty,
+    // then we didn't peel them all:
+    for (size_t i = 0; i < peeled_bucketsPerHash; i++)
+    {
+        uint32_t checksum = peeled.readChecksum(i);
+        if (peeled.hashTable.at(i).empty(checksum) != true)
+            return false;
+    }
+    return true;
+}
+
+CIbltNoCheck CIbltNoCheck::operator-(const CIbltNoCheck &other) const
+{
+    // IBLT's must be same params/size:
+    assert(hashTable.size() == other.hashTable.size());
+
+    CIbltNoCheck result(*this);
+    for (size_t i = 0; i < hashTable.size(); i++)
+    {
+        HashTableEntryNoCheck &e1 = result.hashTable.at(i);
+        const HashTableEntryNoCheck &e2 = other.hashTable.at(i);
+        e1.count -= e2.count;
+        e1.keySum ^= e2.keySum;
+        uint32_t checksum = result.readChecksum(i);
+        checksum ^= other.readChecksum(i);
+        result.writeChecksum(i, checksum);
+        if (e1.empty(checksum))
+        {
+            e1.valueSum.clear();
+        }
+        else
+        {
+            e1.addValue(e2.valueSum);
+        }
+    }
+
+    return result;
+}
+
+uint32_t CIbltNoCheck::readChecksum(size_t entryIdx) const {
+    uint32_t checksum = 0;
+
+    for (int i=0;i < nChecksumBits;i++)
+    {
+        checksum += vChecksums[i + entryIdx*nChecksumBits] << i; 
+    }
+
+    return checksum;
+}
+
+void CIbltNoCheck::writeChecksum(size_t entryIdx, uint32_t checksum) {
+    for (int i=0;i < nChecksumBits;i++)
+    {
+        vChecksums[i + entryIdx*nChecksumBits] = (checksum >> i) % 2;
+    }
+}
+
+// For debugging during development:
+std::string CIbltNoCheck::DumpTable() const
+{
+    std::ostringstream result;
+
+    result << "count keySum keyCheckMatch\n";
+    for (size_t i = 0; i < hashTable.size(); i++)
+    {
+        const HashTableEntryNoCheck &entry = hashTable.at(i);
+        result << entry.count << " " << entry.keySum << " ";
+        uint32_t keyCheck = readChecksum(i);
+        result << (keyChecksumCalcNoCheck(ToVec(entry.keySum), nChecksumBits) == keyCheck ? "true" : "false");
+        result << "\n";
+    }
+
+    return result.str();
+}
+
+size_t CIbltNoCheck::OptimalNHash(size_t expectedNumEntries) { return CIbltParams::Lookup(expectedNumEntries).numhashes; }
+float CIbltNoCheck::OptimalOverhead(size_t expectedNumEntries) { return CIbltParams::Lookup(expectedNumEntries).overhead; }
+uint8_t CIbltNoCheck::MaxNHash()
+{
+    uint8_t maxHashes = 4;
+
+    for (auto &pair : CIbltParams::paramMap)
+    {
+        if (pair.second.numhashes > maxHashes)
+            maxHashes = pair.second.numhashes;
+    }
+
+    return maxHashes;
+}

--- a/src/iblt.h
+++ b/src/iblt.h
@@ -125,13 +125,6 @@ public:
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream &s, Operation ser_action)
     {
-        if (version > 0)
-        {
-            READWRITE(salt);
-            if (salt > VALS_32 / n_hash)
-                throw std::ios_base::failure("salt * n_hash must fit in uint32_t");
-        }
-
         READWRITE(COMPACTSIZE(version));
 
         if (version > 0)
@@ -150,7 +143,6 @@ public:
         }
         READWRITE(is_modified);
         READWRITE(hashTable);
-        READWRITE(mapHashIdxSeeds);
     }
 
     // Returns true if any elements have been inserted into the IBLT since creation or reset

--- a/src/iblt.h
+++ b/src/iblt.h
@@ -125,9 +125,12 @@ public:
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream &s, Operation ser_action)
     {
-        READWRITE(salt);
-        if (salt > VALS_32 / n_hash)
-            throw std::ios_base::failure("salt * n_hash must fit in uint32_t");
+        if (version > 0)
+        {
+            READWRITE(salt);
+            if (salt > VALS_32 / n_hash)
+                throw std::ios_base::failure("salt * n_hash must fit in uint32_t");
+        }
 
         READWRITE(COMPACTSIZE(version));
 

--- a/src/iblt.h
+++ b/src/iblt.h
@@ -29,6 +29,8 @@ SOFTWARE.
 #include <set>
 #include <vector>
 
+static const size_t VALS_32 = 4294967295;
+
 //
 // Invertible Bloom Lookup Table implementation
 // References:
@@ -123,6 +125,10 @@ public:
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream &s, Operation ser_action)
     {
+        READWRITE(salt);
+        if (salt > VALS_32 / n_hash)
+            throw std::ios_base::failure("salt * n_hash must fit in uint32_t");
+
         READWRITE(COMPACTSIZE(version));
 
         if (version > 0)
@@ -141,6 +147,7 @@ public:
         }
         READWRITE(is_modified);
         READWRITE(hashTable);
+        READWRITE(mapHashIdxSeeds);
     }
 
     // Returns true if any elements have been inserted into the IBLT since creation or reset

--- a/src/iblt.h
+++ b/src/iblt.h
@@ -24,10 +24,13 @@ SOFTWARE.
 #define CIblt_H
 
 #include "serialize.h"
+#include "util.h"
 
+#include <boost/dynamic_bitset.hpp>
 #include <inttypes.h>
 #include <set>
 #include <vector>
+#include <iostream>
 
 static const size_t VALS_32 = 4294967295;
 
@@ -133,13 +136,15 @@ public:
             READWRITE(salt);
         }
 
-        if (ser_action.ForRead() && version > 1)
+        if (ser_action.ForRead() && version > 1){
+            LOG(GRAPHENE, "VERSION ERROR IN IBLT: %d\n", version);
             throw std::ios_base::failure("No IBLT version exceeding 1 is currently known.");
+        }
 
         READWRITE(n_hash);
         if (ser_action.ForRead() && n_hash == 0)
         {
-            throw std::ios_base::failure("Number of IBLT hash functions needs to be > 0");
+            throw std::ios_base::failure("CIblt Number of IBLT hash functions needs to be > 0");
         }
         READWRITE(is_modified);
         READWRITE(hashTable);
@@ -158,6 +163,151 @@ protected:
     bool is_modified;
 
     std::vector<HashTableEntry> hashTable;
+    std::map<uint8_t, uint32_t> mapHashIdxSeeds;
+};
+
+// Beginning at version 2 and higher, new features will be added to the implementations
+// of HashTableEntry and CIblt defined below. The reason for the split is the removal of
+// the keyCheck field from HashTableEntry, which cannot be retrofitted to the old implementation.
+
+class HashTableEntryNoCheck
+{
+public:
+    int32_t count;
+    uint64_t keySum;
+    std::vector<uint8_t> valueSum;
+
+    HashTableEntryNoCheck() : count(0), keySum(0) {}
+    bool isPure(uint32_t checksum, uint32_t checksumSpace) const;
+    bool empty(uint32_t checksum) const;
+    void addValue(const std::vector<uint8_t> &v);
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream &s, Operation ser_action)
+    {
+        READWRITE(count);
+        READWRITE(keySum);
+        READWRITE(valueSum);
+    }
+};
+
+class CIbltNoCheck
+{
+public:
+    // Default constructor builds a 0 size IBLT, so is meant for two-phase construction.  Call resize() before use
+    CIbltNoCheck();
+    CIbltNoCheck(uint64_t _version);
+    // Pass the expected number of entries in the IBLT table. If the number of entries exceeds
+    // the expected, then the decode failure rate will increase dramatically.
+    CIbltNoCheck(size_t _expectedNumEntries, uint64_t _version);
+    // The salt value is used to create a distinct hash seed for each hash function.
+    CIbltNoCheck(size_t _expectedNumEntries, uint32_t salt, uint64_t _version);
+    // nChecksumBits checksum bits will be used per cell for the purpose of detecting garbage contents
+    CIbltNoCheck(size_t _expectedNumEntries, uint32_t salt, uint64_t _version, uint8_t _nChecksumBits);
+    // Copy constructor
+    CIbltNoCheck(const CIbltNoCheck &other);
+    ~CIbltNoCheck();
+
+    // Clears all entries in the IBLT
+    void reset();
+    // Returns the size in bytes of the IBLT.  This is NOT the count of inserted entries
+    uint64_t size();
+    void resize(size_t _expectedNumEntries);
+    uint32_t saltedHashValue(size_t hashFuncIdx, const std::vector<uint8_t> &kvec) const;
+    void insert(uint64_t k, const std::vector<uint8_t> &v);
+    void erase(uint64_t k, const std::vector<uint8_t> &v);
+
+    // Returns true if a result is definitely found or not
+    // found. If not found, result will be empty.
+    // Returns false if overloaded and we don't know whether or
+    // not k is in the table.
+    bool get(uint64_t k, std::vector<uint8_t> &result) const;
+
+    // Adds entries to the given sets:
+    //  positive is all entries that were inserted
+    //  negative is all entreis that were erased but never added (or
+    //   if the IBLT = A-B, all entries in B that are not in A)
+    // Returns true if all entries could be decoded, false otherwise.
+    bool listEntries(std::set<std::pair<uint64_t, std::vector<uint8_t> > > &positive,
+        std::set<std::pair<uint64_t, std::vector<uint8_t> > > &negative) const;
+
+    // Subtract two IBLTs
+    CIbltNoCheck operator-(const CIbltNoCheck &other) const;
+
+    // Read checksum for cell "entry" from the global checksum bit array
+    uint32_t readChecksum(size_t entryIdx) const;
+    // Write checksum for cell "entry" to the global checksum bit array
+    void writeChecksum(size_t entryIdx, uint32_t checksum);
+
+    // Returns the optimal number of hash buckets for a certain number of entries
+    static size_t OptimalNHash(size_t expectedNumEntries);
+    // Returns the optimal ratio of memory cells to expected entries.
+    // OptimalOverhead()*expectedNumEntries <= allocated memory cells
+    static float OptimalOverhead(size_t expectedNumEntries);
+    // Returns the maximum number of hash functions for any number of entries.
+    static uint8_t MaxNHash();
+
+    // For debugging:
+    std::string DumpTable() const;
+    uint8_t getNHash() { return n_hash; }
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream &s, Operation ser_action)
+    {
+        READWRITE(COMPACTSIZE(version));
+
+        if (version > 0)
+        {
+            READWRITE(mapHashIdxSeeds);
+            READWRITE(salt);
+        }
+
+        if (ser_action.ForRead() && version > 2)
+            throw std::ios_base::failure("No IBLT version exceeding 2 is currently known.");
+
+        READWRITE(n_hash);
+        if (ser_action.ForRead() && n_hash == 0)
+        {
+            throw std::ios_base::failure("Number of IBLT hash functions needs to be > 0");
+        }
+        READWRITE(is_modified);
+        READWRITE(hashTable);
+
+        READWRITE(nChecksumBits);
+        if (!ser_action.ForRead()) 
+        {
+            vChecksumBlocks.resize(vChecksums.num_blocks());
+            boost::to_block_range(vChecksums, vChecksumBlocks.begin());
+        }
+        READWRITE(vChecksumBlocks);
+        if (ser_action.ForRead()) 
+        {
+            vChecksums.resize(8 * vChecksumBlocks.size());
+            boost::from_block_range(vChecksumBlocks.begin(), vChecksumBlocks.end(), vChecksums);
+        }
+    }
+
+    // Returns true if any elements have been inserted into the IBLT since creation or reset
+    inline bool isModified() { return is_modified; }
+protected:
+    void _insert(int plusOrMinus, uint64_t k, const std::vector<uint8_t> &v);
+
+    // This salt is used to seed the IBLT hash functions. When its value (passed in via constructor)
+    // is derived from a pseudo-random value, the IBLT hash functions themselves become randomized.
+    uint8_t nChecksumBits;
+    // This member holds the checksum bits for all cells, but it is never serialized
+    boost::dynamic_bitset<uint8_t, std::allocator<uint8_t>> vChecksums;
+    // This member holds the compressed contents of vChecksums; it is used for serialization / deserialization
+    std::vector<uint8_t> vChecksumBlocks;
+    uint32_t salt;
+    uint64_t version;
+    uint8_t n_hash;
+    bool is_modified;
+
+    std::vector<HashTableEntryNoCheck> hashTable;
     std::map<uint8_t, uint32_t> mapHashIdxSeeds;
 };
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -840,6 +840,9 @@ bool AppInit2(Config &config, thread_group &threadGroup)
     // BUIPXXX Graphene Blocks: begin section initialize Graphene service
     if (GetBoolArg("-use-grapheneblocks", DEFAULT_USE_GRAPHENE_BLOCKS))
         nLocalServices |= NODE_GRAPHENE;
+
+    if (GetBoolArg("-compute-optimize-graphene", COMPUTE_OPTIMIZE_GRAPHENE))
+        computeOptimizeGraphene = true;
     // BUIPXXX Graphene Blocks: end section
 
     // UAHF - BitcoinCash service bit

--- a/src/main.h
+++ b/src/main.h
@@ -154,6 +154,7 @@ static const bool DEFAULT_PEERBLOOMFILTERS = true;
 static const bool DEFAULT_USE_THINBLOCKS = true;
 static const uint64_t DEFAULT_PREFERENTIAL_TIMER = 1000;
 static const bool DEFAULT_USE_GRAPHENE_BLOCKS = true;
+static const bool COMPUTE_OPTIMIZE_GRAPHENE = false;
 static const bool DEFAULT_USE_COMPACT_BLOCKS = true;
 
 static const bool DEFAULT_REINDEX = false;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -96,6 +96,7 @@ struct ListenSocket
 bool fDiscover = true;
 bool fListen = true;
 uint64_t nLocalServices = NODE_NETWORK;
+bool computeOptimizeGraphene = false;
 // BU moved to globals.cpp: CCriticalSection cs_mapLocalHost;
 // BU moved to globals.cpp: map<CNetAddr, LocalServiceInfo> mapLocalHost;
 static bool vfLimited[NET_MAX] = {};

--- a/src/net.h
+++ b/src/net.h
@@ -489,14 +489,6 @@ public:
     int grapheneBlockWaitingForTxns; // if -1 then not currently waiting
     CCriticalSection cs_grapheneadditionaltxs; // lock grapheneAdditionalTxs
     std::vector<CTransactionRef> grapheneAdditionalTxs; // entire transactions included in graphene block
-    uint64_t shorttxidk0; // Used for generating cheap hash from SipHash
-    uint64_t shorttxidk1;
-
-    std::atomic<double> nGetGrapheneBlockTxCount; // Count how many get_xblocktx requests are made
-    std::atomic<uint64_t> nGetGrapheneBlockTxLastTime; // The last time a get_xblocktx request was made
-    std::atomic<double> nGetGrapheneCount; // Count how many get_graphene requests are made
-    std::atomic<uint64_t> nGetGrapheneLastTime; // The last time a get_graphene request was made
-    uint32_t nGrapheneBloomfilterSize; // The maximum graphene bloom filter size (in bytes) that our peer will accept.
     uint64_t gr_shorttxidk0;
     uint64_t gr_shorttxidk1;
     // BUIPXXX Graphene blocks: end section

--- a/src/net.h
+++ b/src/net.h
@@ -190,6 +190,7 @@ extern bool fListen;
 extern uint64_t nLocalServices;
 extern uint64_t nLocalHostNonce;
 extern CAddrMan addrman;
+extern bool computeOptimizeGraphene;
 
 /** Maximum number of connections to simultaneously allow (aka connection slots) */
 extern int nMaxConnections;

--- a/src/net.h
+++ b/src/net.h
@@ -489,6 +489,13 @@ public:
     int grapheneBlockWaitingForTxns; // if -1 then not currently waiting
     CCriticalSection cs_grapheneadditionaltxs; // lock grapheneAdditionalTxs
     std::vector<CTransactionRef> grapheneAdditionalTxs; // entire transactions included in graphene block
+    uint64_t shorttxidk0; // Used for generating cheap hash from SipHash
+    uint64_t shorttxidk1;
+
+    std::atomic<double> nGetGrapheneBlockTxCount; // Count how many get_xblocktx requests are made
+    std::atomic<uint64_t> nGetGrapheneBlockTxLastTime; // The last time a get_xblocktx request was made
+    std::atomic<double> nGetGrapheneCount; // Count how many get_graphene requests are made
+    std::atomic<uint64_t> nGetGrapheneLastTime; // The last time a get_graphene request was made
     uint32_t nGrapheneBloomfilterSize; // The maximum graphene bloom filter size (in bytes) that our peer will accept.
     uint64_t gr_shorttxidk0;
     uint64_t gr_shorttxidk1;

--- a/src/net.h
+++ b/src/net.h
@@ -489,6 +489,7 @@ public:
     int grapheneBlockWaitingForTxns; // if -1 then not currently waiting
     CCriticalSection cs_grapheneadditionaltxs; // lock grapheneAdditionalTxs
     std::vector<CTransactionRef> grapheneAdditionalTxs; // entire transactions included in graphene block
+    uint32_t nGrapheneBloomfilterSize; // The maximum graphene bloom filter size (in bytes) that our peer will accept.
     uint64_t gr_shorttxidk0;
     uint64_t gr_shorttxidk1;
     // BUIPXXX Graphene blocks: end section

--- a/src/net.h
+++ b/src/net.h
@@ -491,7 +491,6 @@ public:
     std::vector<CTransactionRef> grapheneAdditionalTxs; // entire transactions included in graphene block
     uint64_t shorttxidk0; // Used for generating cheap hash from SipHash
     uint64_t shorttxidk1;
-    bool useSipHash;
 
     std::atomic<double> nGetGrapheneBlockTxCount; // Count how many get_xblocktx requests are made
     std::atomic<uint64_t> nGetGrapheneBlockTxLastTime; // The last time a get_xblocktx request was made

--- a/src/net.h
+++ b/src/net.h
@@ -491,6 +491,7 @@ public:
     std::vector<CTransactionRef> grapheneAdditionalTxs; // entire transactions included in graphene block
     uint64_t shorttxidk0; // Used for generating cheap hash from SipHash
     uint64_t shorttxidk1;
+    bool useSipHash;
 
     std::atomic<double> nGetGrapheneBlockTxCount; // Count how many get_xblocktx requests are made
     std::atomic<uint64_t> nGetGrapheneBlockTxLastTime; // The last time a get_xblocktx request was made

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -533,7 +533,7 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
         CXVersionMessage xver;
         xver.set_u64c(XVer::BU_LISTEN_PORT, GetListenPort());
         xver.set_u64c(XVer::BU_MSG_IGNORE_CHECKSUM, 1); // we will ignore 0 value msg checksums
-        xver.set_u64c(XVer::BU_GRAPHENE_VERSION_SUPPORTED, 3);
+        xver.set_u64c(XVer::BU_GRAPHENE_VERSION_SUPPORTED, 4);
         xver.set_u64c(XVer::BU_XTHIN_VERSION, 2); // xthin version
         pfrom->PushMessage(NetMsgType::XVERSION, xver);
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -533,7 +533,7 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
         CXVersionMessage xver;
         xver.set_u64c(XVer::BU_LISTEN_PORT, GetListenPort());
         xver.set_u64c(XVer::BU_MSG_IGNORE_CHECKSUM, 1); // we will ignore 0 value msg checksums
-        xver.set_u64c(XVer::BU_GRAPHENE_VERSION_SUPPORTED, 4);
+        xver.set_u64c(XVer::BU_GRAPHENE_VERSION_SUPPORTED, 5);
         xver.set_u64c(XVer::BU_XTHIN_VERSION, 2); // xthin version
         pfrom->PushMessage(NetMsgType::XVERSION, xver);
 

--- a/src/test/fastfilter_tests.cpp
+++ b/src/test/fastfilter_tests.cpp
@@ -11,6 +11,58 @@
 
 BOOST_FIXTURE_TEST_SUITE(fastfilter_tests, BasicTestingSetup)
 
+BOOST_AUTO_TEST_CASE(variablefastfilter_tests)
+{
+    // Like a bloom filter the fast filter can have false positives but not false negatives
+    FastRandomContext insecure_rand;
+    {
+        int n = 4 * 1024 * 1024;
+        double fpr = 0.1;
+        int buffer = 2;
+        CVariableFastFilter filt(n, fpr);
+
+        //  pick a random start point for a randomized test
+        // arith_uint256 num(insecure_rand.rand32());
+        arith_uint256 num(1);
+        arith_uint256 origNum = num;
+        int collisions = 0;
+        for (int i = 1; i < 50000; i++)
+        {
+            num += 1;
+            uint256 t1 = ArithToUint256(num);
+            // for the fastfilter to work without lots of collisions the data must be pseudo-random
+            uint256 tmp = Hash(t1.begin(), t1.end());
+            if (filt.contains(tmp))
+            {
+                collisions++;
+            }
+            filt.insert(tmp);
+            BOOST_CHECK(filt.contains(tmp));
+            BOOST_CHECK(!filt.checkAndSet(tmp));
+        }
+        BOOST_CHECK(collisions < 10); // sanity check, actual result may vary
+        // check them all again
+        num = origNum;
+        int numFalsePositives = 0;
+        for (int i = 1; i < 50000; i++)
+        {
+            num += 1;
+            uint256 t1 = ArithToUint256(num);
+            uint256 tmp = Hash(t1.begin(), t1.end());
+            BOOST_CHECK(filt.contains(tmp));
+        }
+        for (int i = 1; i < 50000; i++) // check a bunch of numbers we didn't add
+        {
+            num += 1;
+            uint256 t1 = ArithToUint256(num);
+            uint256 tmp = Hash(t1.begin(), t1.end());
+            if (filt.contains(tmp))
+                numFalsePositives++;
+        }
+        BOOST_CHECK(numFalsePositives < buffer*n*fpr); // sanity check, actual result may vary
+    }
+}
+
 BOOST_AUTO_TEST_CASE(fastfilter_tests)
 {
     // Like a bloom filter the fast filter can have false positives but not false negatives

--- a/src/test/fastfilter_tests.cpp
+++ b/src/test/fastfilter_tests.cpp
@@ -59,7 +59,7 @@ BOOST_AUTO_TEST_CASE(variablefastfilter_tests)
             if (filt.contains(tmp))
                 numFalsePositives++;
         }
-        BOOST_CHECK(numFalsePositives < buffer*n*fpr); // sanity check, actual result may vary
+        BOOST_CHECK(numFalsePositives < buffer * n * fpr); // sanity check, actual result may vary
     }
 }
 

--- a/src/test/graphene_tests.cpp
+++ b/src/test/graphene_tests.cpp
@@ -274,19 +274,19 @@ BOOST_AUTO_TEST_CASE(compute_optimized_graphene_set_can_serde)
 
 BOOST_AUTO_TEST_CASE(graphene_block_can_serde)
 {
-    CBlock block;
-    CTransaction tx;
-    CDataStream stream(
-        ParseHex("01000000010b26e9b7735eb6aabdf358bab62f9816a21ba9ebdb719d5299e88607d722c190000000008b4830450220070aca4"
-                 "4506c5cef3a16ed519d7c3c39f8aab192c4e1c90d065f37b8a4af6141022100a8e160b856c2d43d27d8fba71e5aef6405b864"
-                 "3ac4cb7cb3c462aced7f14711a0141046d11fee51b0e60666d5049a9101a72741df480b96ee26488a4d3466b95c9a40ac5eee"
-                 "f87e10a5cd336c19a84565f80fa6c547957b7700ff4dfbdefe76036c339ffffffff021bff3d11000000001976a91404943fdd"
-                 "508053c75000106d3bc6e2754dbcff1988ac2f15de00000000001976a914a266436d2965547608b9e15d9032a7b9d64fa4318"
-                 "8ac00000000"),
-        SER_DISK, CLIENT_VERSION);
 
     // regular graphene block
     {
+        CBlock block;
+        CTransaction tx;
+        CDataStream stream(
+            ParseHex("01000000010b26e9b7735eb6aabdf358bab62f9816a21ba9ebdb719d5299e88607d722c190000000008b4830450220070aca4"
+                     "4506c5cef3a16ed519d7c3c39f8aab192c4e1c90d065f37b8a4af6141022100a8e160b856c2d43d27d8fba71e5aef6405b864"
+                     "3ac4cb7cb3c462aced7f14711a0141046d11fee51b0e60666d5049a9101a72741df480b96ee26488a4d3466b95c9a40ac5eee"
+                     "f87e10a5cd336c19a84565f80fa6c547957b7700ff4dfbdefe76036c339ffffffff021bff3d11000000001976a91404943fdd"
+                     "508053c75000106d3bc6e2754dbcff1988ac2f15de00000000001976a914a266436d2965547608b9e15d9032a7b9d64fa4318"
+                     "8ac00000000"),
+            SER_DISK, CLIENT_VERSION);
         stream >> tx;
         const CTransactionRef ptx = MakeTransactionRef(tx);
         block.vtx.push_back(ptx);
@@ -300,6 +300,16 @@ BOOST_AUTO_TEST_CASE(graphene_block_can_serde)
     
     // compute optimized graphene block
     {
+        CBlock block;
+        CTransaction tx;
+        CDataStream stream(
+            ParseHex("01000000010b26e9b7735eb6aabdf358bab62f9816a21ba9ebdb719d5299e88607d722c190000000008b4830450220070aca4"
+                     "4506c5cef3a16ed519d7c3c39f8aab192c4e1c90d065f37b8a4af6141022100a8e160b856c2d43d27d8fba71e5aef6405b864"
+                     "3ac4cb7cb3c462aced7f14711a0141046d11fee51b0e60666d5049a9101a72741df480b96ee26488a4d3466b95c9a40ac5eee"
+                     "f87e10a5cd336c19a84565f80fa6c547957b7700ff4dfbdefe76036c339ffffffff021bff3d11000000001976a91404943fdd"
+                     "508053c75000106d3bc6e2754dbcff1988ac2f15de00000000001976a914a266436d2965547608b9e15d9032a7b9d64fa4318"
+                     "8ac00000000"),
+            SER_DISK, CLIENT_VERSION);
         stream >> tx;
         const CTransactionRef ptx = MakeTransactionRef(tx);
         block.vtx.push_back(ptx);

--- a/src/test/graphene_tests.cpp
+++ b/src/test/graphene_tests.cpp
@@ -284,15 +284,33 @@ BOOST_AUTO_TEST_CASE(graphene_block_can_serde)
                  "508053c75000106d3bc6e2754dbcff1988ac2f15de00000000001976a914a266436d2965547608b9e15d9032a7b9d64fa4318"
                  "8ac00000000"),
         SER_DISK, CLIENT_VERSION);
-    stream >> tx;
-    const CTransactionRef ptx = MakeTransactionRef(tx);
-    block.vtx.push_back(ptx);
-    CGrapheneBlock senderGrapheneBlock(MakeBlockRef(block), 5, 6, 2);
-    CGrapheneBlock receiverGrapheneBlock(2);
-    CDataStream ss(SER_DISK, 0);
 
-    ss << senderGrapheneBlock;
-    ss >> receiverGrapheneBlock;
+    // regular graphene block
+    {
+        stream >> tx;
+        const CTransactionRef ptx = MakeTransactionRef(tx);
+        block.vtx.push_back(ptx);
+        CGrapheneBlock senderGrapheneBlock(MakeBlockRef(block), 5, 6, 4, false);
+        CGrapheneBlock receiverGrapheneBlock(4);
+        CDataStream ss(SER_DISK, 0);
+
+        ss << senderGrapheneBlock;
+        ss >> receiverGrapheneBlock;
+    }
+    
+    // compute optimized graphene block
+    {
+        stream >> tx;
+        const CTransactionRef ptx = MakeTransactionRef(tx);
+        block.vtx.push_back(ptx);
+        CGrapheneBlock senderGrapheneBlock(MakeBlockRef(block), 5, 6, 4, false);
+        CGrapheneBlock receiverGrapheneBlock(4);
+        CDataStream ss(SER_DISK, 0);
+
+        ss << senderGrapheneBlock;
+        ss >> receiverGrapheneBlock;
+    }
 }
+
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/graphene_tests.cpp
+++ b/src/test/graphene_tests.cpp
@@ -53,7 +53,7 @@ BOOST_AUTO_TEST_CASE(graphene_set_encodes_and_decodes)
 
     // unordered graphene sets
     {
-        CGrapheneSet senderGrapheneSet(6, 6, senderItems, 0, 0, 0, 0, false, true);
+        CGrapheneSet senderGrapheneSet(6, 6, senderItems, 0, 0, 0, 0, false, false, true);
         std::vector<uint64_t> reconciledCheapHashes = senderGrapheneSet.Reconcile(receiverItems);
 
         std::vector<uint64_t> senderCheapHashes;
@@ -70,7 +70,7 @@ BOOST_AUTO_TEST_CASE(graphene_set_encodes_and_decodes)
 
     // ordered graphene sets
     {
-        CGrapheneSet senderGrapheneSet(6, 6, senderItems, 0, 0, 0, 0, true, true);
+        CGrapheneSet senderGrapheneSet(6, 6, senderItems, 0, 0, 0, 0, false, true, true);
         std::vector<uint64_t> reconciledCheapHashes = senderGrapheneSet.Reconcile(receiverItems);
 
         std::vector<uint64_t> senderCheapHashes;
@@ -110,7 +110,7 @@ BOOST_AUTO_TEST_CASE(graphene_set_decodes_multiple_sizes)
             }
 
             CGrapheneSet senderGrapheneSet(
-                receiverItems.size(), receiverItems.size(), senderItems, 0, 0, 0, 0, true, true);
+                receiverItems.size(), receiverItems.size(), senderItems, 0, 0, 0, 0, false, true, true);
             std::vector<uint64_t> reconciledCheapHashes = senderGrapheneSet.Reconcile(receiverItems);
 
             BOOST_CHECK_EQUAL_COLLECTIONS(reconciledCheapHashes.begin(), reconciledCheapHashes.end(),
@@ -127,7 +127,7 @@ BOOST_AUTO_TEST_CASE(graphene_set_decodes_multiple_sizes)
             }
 
             CGrapheneSet senderGrapheneSet(
-                receiverItems.size(), receiverItems.size(), senderItems, 0, 0, 0, 0, true, true);
+                receiverItems.size(), receiverItems.size(), senderItems, 0, 0, 0, 0, false, true, true);
             std::vector<uint64_t> reconciledCheapHashes = senderGrapheneSet.Reconcile(receiverItems);
 
             BOOST_CHECK_EQUAL_COLLECTIONS(reconciledCheapHashes.begin(), reconciledCheapHashes.end(),
@@ -201,7 +201,7 @@ BOOST_AUTO_TEST_CASE(graphene_set_decodes_empty_intersection)
         SerializeHash(-5), SerializeHash(-11)};
     std::vector<uint256> receiverItems(receiverArr, receiverArr + sizeof(receiverArr) / sizeof(uint256));
 
-    CGrapheneSet senderGrapheneSet(6, 12, senderItems, 0, 0, 0, 0, true, true);
+    CGrapheneSet senderGrapheneSet(6, 12, senderItems, 0, 0, 0, 0, false, true, true);
     std::vector<uint64_t> reconciledCheapHashes = senderGrapheneSet.Reconcile(receiverItems);
 
     std::vector<uint64_t> senderCheapHashes;
@@ -218,8 +218,8 @@ BOOST_AUTO_TEST_CASE(graphene_set_can_serde)
     CDataStream ss(SER_DISK, 0);
 
     senderItems.push_back(SerializeHash(3));
-    CGrapheneSet sentGrapheneSet(1, 1, senderItems, 0, 0, 0, 0, false, true);
-    CGrapheneSet receivedGrapheneSet(false);
+    CGrapheneSet sentGrapheneSet(1, 1, senderItems, 0, 0, 0, 0, false, false, true);
+    CGrapheneSet receivedGrapheneSet(0);
 
     ss << sentGrapheneSet;
     ss >> receivedGrapheneSet;
@@ -229,7 +229,7 @@ BOOST_AUTO_TEST_CASE(graphene_set_can_serde)
 
 BOOST_AUTO_TEST_CASE(graphene_set_version_check)
 {
-    for (uint64_t version=0;version <= MAX_GRAPHENE_SET_VERSION;version++)
+    for (uint64_t version = 0; version <= MAX_GRAPHENE_SET_VERSION; version++)
     {
         std::vector<uint256> senderItems;
         CDataStream ss(SER_DISK, 0);
@@ -237,7 +237,7 @@ BOOST_AUTO_TEST_CASE(graphene_set_version_check)
         senderItems.push_back(SerializeHash(1));
         senderItems.push_back(SerializeHash(2));
         senderItems.push_back(SerializeHash(3));
-        CGrapheneSet sentGrapheneSet(3, 3, senderItems, 0, 0, version, false, true);
+        CGrapheneSet sentGrapheneSet(3, 3, senderItems, 0, 0, version, false, false, true);
         CGrapheneSet receivedGrapheneSet(version);
 
         ss << sentGrapheneSet;
@@ -255,6 +255,21 @@ BOOST_AUTO_TEST_CASE(item_rank_encodes_and_decodes)
     std::vector<uint64_t> outputItems = CGrapheneSet::DecodeRank(encoded, inputItems.size(), nBits);
 
     BOOST_CHECK_EQUAL_COLLECTIONS(outputItems.begin(), outputItems.end(), inputItems.begin(), inputItems.end());
+}
+
+BOOST_AUTO_TEST_CASE(compute_optimized_graphene_set_can_serde)
+{
+    std::vector<uint256> senderItems;
+    CDataStream ss(SER_DISK, 0);
+
+    senderItems.push_back(SerializeHash(3));
+    CGrapheneSet sentGrapheneSet(1, 1, senderItems, 0, 0, 3, 0, true, false, true);
+    CGrapheneSet receivedGrapheneSet(3);
+
+    ss << sentGrapheneSet;
+    ss >> receivedGrapheneSet;
+
+    BOOST_CHECK_EQUAL(receivedGrapheneSet.Reconcile(senderItems)[0], sentGrapheneSet.GetShortID(senderItems[0]));
 }
 
 BOOST_AUTO_TEST_CASE(graphene_block_can_serde)

--- a/src/test/graphene_tests.cpp
+++ b/src/test/graphene_tests.cpp
@@ -16,7 +16,7 @@
 #include <iostream>
 #include <iomanip>
 
-#define MAX_GRAPHENE_SET_VERSION 1
+#define MAX_GRAPHENE_SET_VERSION 4
 
 size_t ProjectedGrapheneSizeBytes(uint64_t nBlockTxs, uint64_t nExcessTxs, uint64_t nSymDiff, bool computeOptimized=false)
 {
@@ -42,6 +42,34 @@ size_t ProjectedGrapheneSizeBytes(uint64_t nBlockTxs, uint64_t nExcessTxs, uint6
 
     return filterBytes + ibltBytes;
 }
+
+size_t ProjectedGrapheneSizeBytesNoCheck(uint64_t nBlockTxs, uint64_t nExcessTxs, uint64_t nSymDiff, uint8_t nChecksumBits, bool computeOptimized=false)
+{
+    const int SERIALIZATION_OVERHEAD = 11;
+    FastRandomContext insecure_rand(true);
+    auto fpr = [nExcessTxs](int a) { return a / float(nExcessTxs); };
+
+    uint32_t ibltSalt = 13;
+    uint64_t ibltVersion = 2;
+    CIbltNoCheck iblt(nSymDiff, ibltSalt, ibltVersion, nChecksumBits);
+    size_t ibltBytes = ::GetSerializeSize(iblt, SER_NETWORK, PROTOCOL_VERSION) - SERIALIZATION_OVERHEAD;
+
+    size_t filterBytes;
+    if (computeOptimized)
+    {
+        CVariableFastFilter filter(nBlockTxs, fpr(nSymDiff));
+        filterBytes = ::GetSerializeSize(filter, SER_NETWORK, PROTOCOL_VERSION) - SERIALIZATION_OVERHEAD;
+    }
+    else
+    {
+        CBloomFilter filter(
+            nBlockTxs, fpr(nSymDiff), insecure_rand.rand32(), BLOOM_UPDATE_ALL, true, std::numeric_limits<uint32_t>::max());
+        filterBytes = ::GetSerializeSize(filter, SER_NETWORK, PROTOCOL_VERSION) - SERIALIZATION_OVERHEAD;
+    }
+
+    return filterBytes + ibltBytes;
+}
+
 
 // Create a deterministic hash by providing an index
 uint256 GetHash(unsigned int nIndex)
@@ -147,7 +175,7 @@ BOOST_AUTO_TEST_CASE(graphene_set_decodes_multiple_sizes)
     }
 }
 
-BOOST_AUTO_TEST_CASE(graphene_set_finds_brute_force_opt_for_small_blocks)
+BOOST_AUTO_TEST_CASE(with_check_graphene_set_finds_brute_force_opt_for_small_blocks)
 {
     CGrapheneSet grapheneSet(0);
 
@@ -175,6 +203,37 @@ BOOST_AUTO_TEST_CASE(graphene_set_finds_brute_force_opt_for_small_blocks)
     BOOST_CHECK_EQUAL(grapheneSet.OptimalSymDiff(n, m, m - mu, 1), best_a);
 }
 
+BOOST_AUTO_TEST_CASE(graphene_set_finds_brute_force_opt_for_small_blocks)
+{
+    CGrapheneSet grapheneSet(0);
+
+    int n = (int)std::floor(APPROX_ITEMS_THRESH_NO_CHECK / 2);
+    int mu = 100;
+    int m = (int)std::floor(n / 8) + mu;
+
+    int best_a = 1;
+    size_t best_size = std::numeric_limits<size_t>::max();
+    int a = 1;
+    for (a = 1; a < m - mu; a++)
+    {
+		for (uint8_t nChecksumBits=1;nChecksumBits < 33;nChecksumBits++)
+		{
+			size_t totalBytes = ProjectedGrapheneSizeBytesNoCheck(n, m - mu, a, nChecksumBits);
+			size_t totalBytesOpt = ProjectedGrapheneSizeBytesNoCheck(n, m - mu, a, nChecksumBits, true);
+
+			BOOST_CHECK_EQUAL(totalBytes, totalBytesOpt);
+
+			if (totalBytes < best_size)
+			{
+				best_size = totalBytes;
+				best_a = a;
+			}
+		}
+    }
+
+    BOOST_CHECK_EQUAL(grapheneSet.OptimalSymDiff(n, m, m - mu, 1), best_a);
+}
+
 BOOST_AUTO_TEST_CASE(graphene_set_finds_approx_opt_for_large_blocks)
 {
     int n = 4 * APPROX_ITEMS_THRESH;
@@ -183,18 +242,18 @@ BOOST_AUTO_TEST_CASE(graphene_set_finds_approx_opt_for_large_blocks)
     CGrapheneSet grapheneSet(0);
     auto approxSymDiff = [n]() {
         return std::max(
-            1.0, std::round(FILTER_CELL_SIZE * n / (8 * IBLT_CELL_SIZE * IBLT_DEFAULT_OVERHEAD * LN2SQUARED)));
+            1.0, std::round(FILTER_CELL_SIZE * n / ((MAX_CHECKSUM_BITS + 8 * IBLT_FIXED_CELL_SIZE) * IBLT_DEFAULT_OVERHEAD * LN2SQUARED)));
     };
 
     BOOST_CHECK_EQUAL(approxSymDiff(), grapheneSet.OptimalSymDiff(n, m, m - mu, 0));
 }
 
-BOOST_AUTO_TEST_CASE(graphene_set_approx_opt_close_to_optimal)
+BOOST_AUTO_TEST_CASE(with_check_graphene_set_approx_opt_close_to_optimal)
 {
     int n = APPROX_ITEMS_THRESH;
     int mu = 100;
     int m = (int)std::ceil(n / APPROX_EXCESS_RATE) + mu;
-    CGrapheneSet grapheneSet(0);
+    CGrapheneSet grapheneSet(4);
 
     float totalBytesApprox = (float)ProjectedGrapheneSizeBytes(n, m - mu, grapheneSet.ApproxOptimalSymDiff(n));
     float totalBytesBrute =
@@ -203,6 +262,29 @@ BOOST_AUTO_TEST_CASE(graphene_set_approx_opt_close_to_optimal)
         (float)ProjectedGrapheneSizeBytes(n, m - mu, grapheneSet.BruteForceSymDiff(n, m, m - mu, 0), true);
 
     BOOST_CHECK_CLOSE(totalBytesApprox, totalBytesBrute, 15);
+    BOOST_CHECK_CLOSE(totalBytesApprox, totalBytesBruteOpt, 15);
+}
+
+BOOST_AUTO_TEST_CASE(graphene_set_approx_opt_close_to_optimal)
+{
+    int n = APPROX_ITEMS_THRESH;
+    int mu = 100;
+    int m = (int)std::ceil(n / APPROX_EXCESS_RATE) + mu;
+    uint64_t grapheneSetVersion = 4;
+    CGrapheneSet grapheneSet(grapheneSetVersion);
+
+	// Get brute optimal diff and estimate optimal checksum bits from that
+    double optSymDiff = grapheneSet.BruteForceSymDiff(n, m, m - mu, 0, MAX_CHECKSUM_BITS);
+	uint64_t nIbltCells = std::max((int)IBLT_CELL_MINIMUM, (int)ceil(optSymDiff));
+    uint8_t nChecksumBits = CGrapheneSet::NChecksumBits(nIbltCells * CIblt::OptimalOverhead(nIbltCells),
+                                                        CIblt::OptimalNHash(nIbltCells),
+                                                        m,
+                                                        CGrapheneSet::BloomFalsePositiveRate(optSymDiff, m - mu),
+                                                        UNCHECKED_ERROR_TOL);
+
+    float totalBytesApprox = (float)ProjectedGrapheneSizeBytesNoCheck(n, m - mu, grapheneSet.ApproxOptimalSymDiff(n), nChecksumBits);
+    float totalBytesBruteOpt = (float)ProjectedGrapheneSizeBytesNoCheck(n, m - mu, optSymDiff, nChecksumBits, true);
+
     BOOST_CHECK_CLOSE(totalBytesApprox, totalBytesBruteOpt, 15);
 }
 
@@ -231,17 +313,21 @@ BOOST_AUTO_TEST_CASE(graphene_set_decodes_empty_intersection)
 
 BOOST_AUTO_TEST_CASE(graphene_set_can_serde)
 {
-    std::vector<uint256> senderItems;
-    CDataStream ss(SER_DISK, 0);
+	for (uint64_t version=0;version <= MAX_GRAPHENE_SET_VERSION;version++)
+	{
+		std::vector<uint256> senderItems;
+		CDataStream ss(SER_DISK, 0);
 
-    senderItems.push_back(SerializeHash(3));
-    CGrapheneSet sentGrapheneSet(1, 1, senderItems, 0, 0, 0, 0, false, false, true);
-    CGrapheneSet receivedGrapheneSet(0);
+        uint256 tx = SerializeHash(3); 
+		senderItems.push_back(tx);
+		CGrapheneSet sentGrapheneSet(1, 1, senderItems, 0, 0, version, 0, false, false, true);
+		CGrapheneSet receivedGrapheneSet(version);
 
-    ss << sentGrapheneSet;
-    ss >> receivedGrapheneSet;
+		ss << sentGrapheneSet;
+		ss >> receivedGrapheneSet;
 
-    BOOST_CHECK_EQUAL(receivedGrapheneSet.Reconcile(senderItems)[0], senderItems[0].GetCheapHash());
+		BOOST_CHECK_EQUAL(receivedGrapheneSet.Reconcile(senderItems)[0], sentGrapheneSet.GetShortID(tx));
+	}
 }
 
 BOOST_AUTO_TEST_CASE(graphene_set_version_check)
@@ -387,6 +473,31 @@ BOOST_AUTO_TEST_CASE(graphene_block_can_serde)
         ss << senderGrapheneBlock;
         ss >> receiverGrapheneBlock;
     }
+
+	std::cout<<"BEFORE\n";
+    // using CIbltNoCheck
+    {
+        CBlock block;
+        CTransaction tx;
+        CDataStream stream(
+            ParseHex("01000000010b26e9b7735eb6aabdf358bab62f9816a21ba9ebdb719d5299e88607d722c190000000008b4830450220070aca4"
+                     "4506c5cef3a16ed519d7c3c39f8aab192c4e1c90d065f37b8a4af6141022100a8e160b856c2d43d27d8fba71e5aef6405b864"
+                     "3ac4cb7cb3c462aced7f14711a0141046d11fee51b0e60666d5049a9101a72741df480b96ee26488a4d3466b95c9a40ac5eee"
+                     "f87e10a5cd336c19a84565f80fa6c547957b7700ff4dfbdefe76036c339ffffffff021bff3d11000000001976a91404943fdd"
+                     "508053c75000106d3bc6e2754dbcff1988ac2f15de00000000001976a914a266436d2965547608b9e15d9032a7b9d64fa4318"
+                     "8ac00000000"),
+            SER_DISK, CLIENT_VERSION);
+        stream >> tx;
+        const CTransactionRef ptx = MakeTransactionRef(tx);
+        block.vtx.push_back(ptx);
+        CGrapheneBlock senderGrapheneBlock(MakeBlockRef(block), 5, 6, 5, true);
+        CGrapheneBlock receiverGrapheneBlock(5);
+        CDataStream ss(SER_DISK, 0);
+
+        ss << senderGrapheneBlock;
+        ss >> receiverGrapheneBlock;
+    }
+	std::cout<<"AFTER\n";
 }
 
 

--- a/src/test/iblt_tests.cpp
+++ b/src/test/iblt_tests.cpp
@@ -260,4 +260,297 @@ BOOST_AUTO_TEST_CASE(iblt_performs_subtraction_properly)
     BOOST_CHECK(negative == expectedPositive);
 }
 
+/******** version > 1 *********/
+
+BOOST_AUTO_TEST_CASE(nocheck_iblt_handles_small_quantities)
+{
+    uint64_t version = 2;
+	bool allPassed = true;
+	for (size_t nItems=1;nItems < 100;nItems++)
+	{
+		CIbltNoCheck t(nItems, version);
+
+		for (size_t i=0;i < nItems;i++)
+			t.insert(i, IBLT_NULL_VALUE);
+
+		std::set<std::pair<uint64_t, std::vector<uint8_t> > > entries;
+		allPassed = allPassed && t.listEntries(entries, entries);
+	}
+
+	BOOST_CHECK(allPassed);
+}
+
+BOOST_AUTO_TEST_CASE(nocheck_iblt_arbitrary_salt)
+{
+    uint32_t salt = 17;
+    uint64_t version = 2;
+    size_t nItems = 2;
+    CIbltNoCheck t(nItems, salt, version);
+
+    t.insert(0, ParseHex("00000000"));
+    t.insert(1, ParseHex("00000001"));
+    bool gotResult;
+    std::vector<uint8_t> result;
+
+    gotResult = t.get(0, result);
+    BOOST_CHECK(gotResult && result == ParseHex("00000000"));
+
+    gotResult = t.get(1, result);
+    BOOST_CHECK(gotResult && result == ParseHex("00000001"));
+}
+
+BOOST_AUTO_TEST_CASE(nocheck_iblt_salted_reset)
+{
+    size_t nHash = 1;
+    uint32_t salt = 17;
+    uint64_t version = 2;
+    bool gotResult;
+    std::vector<uint8_t> result;
+    CIbltNoCheck t(nHash, salt, version);
+
+    t.insert(0, ParseHex("00000000"));
+    gotResult = t.get(0, result);
+    BOOST_CHECK(gotResult && result == ParseHex("00000000"));
+
+    t.reset();
+    t.resize(20);
+    t.insert(1, ParseHex("00000001"));
+    t.insert(11, ParseHex("00000011"));
+
+    gotResult = t.get(1, result);
+    BOOST_CHECK(gotResult && result == ParseHex("00000001"));
+}
+
+BOOST_AUTO_TEST_CASE(nocheck_iblt_reset)
+{
+    uint64_t version = 2;
+    CIbltNoCheck t(version);
+    t.insert(0, ParseHex("00000000"));
+    bool gotResult;
+    std::vector<uint8_t> result;
+    gotResult = t.get(21, result);
+    BOOST_CHECK(!gotResult);  // anything could have been inserted into a zero length IBLT
+
+    t.reset();
+    t.resize(20);
+    t.insert(0, ParseHex("00000000"));
+    t.insert(1, ParseHex("00000001"));
+    t.insert(11, ParseHex("00000011"));
+
+    gotResult = t.get(0, result);
+    BOOST_CHECK(gotResult && result == ParseHex("00000000"));
+
+    t.reset();
+
+    gotResult = t.get(0, result);
+    BOOST_CHECK(gotResult && (result.size()==0));
+
+    t.resize(40);
+
+    t.insert(0, ParseHex("00000000"));
+    t.insert(1, ParseHex("00000001"));
+    t.insert(11, ParseHex("00000011"));
+
+    gotResult = t.get(0, result);
+    BOOST_CHECK(gotResult && result == ParseHex("00000000"));
+}
+
+BOOST_AUTO_TEST_CASE(nocheck_iblt_erases_properly)
+{
+    uint64_t version = 2;
+    CIbltNoCheck t(20, version);
+    t.insert(0, ParseHex("00000000"));
+    t.insert(1, ParseHex("00000001"));
+    t.insert(11, ParseHex("00000011"));
+
+    bool gotResult;
+    std::vector<uint8_t> result;
+    gotResult = t.get(0, result);
+    BOOST_CHECK(gotResult && result == ParseHex("00000000"));
+    gotResult = t.get(11, result);
+    BOOST_CHECK(gotResult && result == ParseHex("00000011"));
+
+    t.erase(0, ParseHex("00000000"));
+    t.erase(1, ParseHex("00000001"));
+    gotResult = t.get(1, result);
+    BOOST_CHECK(gotResult && result.empty());
+    t.erase(11, ParseHex("00000011"));
+    gotResult = t.get(11, result);
+    BOOST_CHECK(gotResult && result.empty());
+
+    t.insert(0, ParseHex("00000000"));
+    t.insert(1, ParseHex("00000001"));
+    t.insert(11, ParseHex("00000011"));
+
+    for (int i = 100; i < 115; i++)
+    {
+        t.insert(i, ParseHex("aabbccdd"));
+    }
+
+    gotResult = t.get(101, result);
+    BOOST_CHECK(gotResult && result == ParseHex("aabbccdd"));
+    gotResult = t.get(200, result);
+    BOOST_CHECK(gotResult && result.empty());
+}
+
+BOOST_AUTO_TEST_CASE(nocheck_iblt_handles_overload)
+{
+    uint64_t version = 2;
+    CIbltNoCheck t(20, version);
+
+    // 1,000 values in an IBLT that has room for 20,
+    // all lookups should fail.
+    for (int i = 0; i < 1000; i++)
+    {
+        t.insert(i, PseudoRandomValue(i));
+    }
+    bool gotResult;
+    std::vector<uint8_t> result;
+    for (int i = 0; i < 1000; i += 97)
+    {
+        gotResult = t.get(i, result);
+        BOOST_CHECK(!gotResult && result.empty());
+    }
+
+    // erase all but 20:
+    for (int i = 20; i < 1000; i++)
+    {
+        t.erase(i, PseudoRandomValue(i));
+    }
+    for (int i = 0; i < 20; i++)
+    {
+        gotResult = t.get(i, result);
+        BOOST_CHECK(gotResult && result == PseudoRandomValue(i));
+    }
+}
+
+BOOST_AUTO_TEST_CASE(nocheck_iblt_lists_entries_properly)
+{
+    uint64_t version = 2;
+    std::set<std::pair<uint64_t, std::vector<uint8_t> > > expected;
+    CIbltNoCheck t(20, version);
+    for (int i = 0; i < 20; i++)
+    {
+        t.insert(i, PseudoRandomValue(i * 2));
+        expected.insert(std::make_pair(i, PseudoRandomValue(i * 2)));
+    }
+    std::set<std::pair<uint64_t, std::vector<uint8_t> > > entries;
+    bool fAllFound = t.listEntries(entries, entries);
+    BOOST_CHECK(fAllFound && entries == expected);
+}
+
+BOOST_AUTO_TEST_CASE(nocheck_iblt_performs_subtraction_properly)
+{
+    uint64_t version = 2;
+    CIbltNoCheck t1(11, version);
+    CIbltNoCheck t2(11, version);
+
+    for (int i = 0; i < 195; i++)
+    {
+        t1.insert(i, PseudoRandomValue(i));
+    }
+    for (int i = 5; i < 200; i++)
+    {
+        t2.insert(i, PseudoRandomValue(i));
+    }
+
+    CIbltNoCheck diff = t1 - t2;
+
+    // Should end up with 10 differences, 5 positive and 5 negative:
+    std::set<std::pair<uint64_t, std::vector<uint8_t> > > expectedPositive;
+    std::set<std::pair<uint64_t, std::vector<uint8_t> > > expectedNegative;
+    for (int i = 0; i < 5; i++)
+    {
+        expectedPositive.insert(std::make_pair(i, PseudoRandomValue(i)));
+        expectedNegative.insert(std::make_pair(195 + i, PseudoRandomValue(195 + i)));
+    }
+    std::set<std::pair<uint64_t, std::vector<uint8_t> > > positive;
+    std::set<std::pair<uint64_t, std::vector<uint8_t> > > negative;
+    bool allDecoded = diff.listEntries(positive, negative);
+    BOOST_CHECK(allDecoded);
+    BOOST_CHECK(positive == expectedPositive);
+    BOOST_CHECK(negative == expectedNegative);
+
+    positive.clear();
+    negative.clear();
+    allDecoded = (t2 - t1).listEntries(positive, negative);
+    BOOST_CHECK(allDecoded);
+    BOOST_CHECK(positive == expectedNegative); // Opposite subtraction, opposite results
+    BOOST_CHECK(negative == expectedPositive);
+
+
+    CIbltNoCheck emptyIBLT(11, version);
+    std::set<std::pair<uint64_t, std::vector<uint8_t> > > emptySet;
+
+    // Test edge cases for empty IBLT:
+    allDecoded = emptyIBLT.listEntries(emptySet, emptySet);
+    BOOST_CHECK(allDecoded);
+    BOOST_CHECK(emptySet.empty());
+
+    positive.clear();
+    negative.clear();
+    allDecoded = (diff - emptyIBLT).listEntries(positive, negative);
+    BOOST_CHECK(allDecoded);
+    BOOST_CHECK(positive == expectedPositive);
+    BOOST_CHECK(negative == expectedNegative);
+
+    positive.clear();
+    negative.clear();
+    allDecoded = (emptyIBLT - diff).listEntries(positive, negative);
+    BOOST_CHECK(allDecoded);
+    BOOST_CHECK(positive == expectedNegative); // Opposite subtraction, opposite results
+    BOOST_CHECK(negative == expectedPositive);
+}
+
+BOOST_AUTO_TEST_CASE(nocheck_iblt_reads_and_writes_checksum_properly)
+{
+    uint64_t version = 2;
+    uint8_t nItems = 10;
+    uint8_t nChecksumBits = 11;
+    uint32_t salt = 5;
+    uint32_t checksum1 = 13;
+    uint32_t checksum2 = 17;
+    CIbltNoCheck t(nItems, salt, version, nChecksumBits);
+
+    for (int i=0;i < nItems;i++)
+        BOOST_CHECK(t.readChecksum(i) == 0);
+
+    t.writeChecksum(5, checksum1);
+    t.writeChecksum(7, checksum2);
+
+    BOOST_CHECK(t.readChecksum(5) == checksum1);
+    BOOST_CHECK(t.readChecksum(7) == checksum2);
+
+    for (int i=0;i < nItems;i++) {
+        if (i == 5 || i == 7)
+            continue;
+
+        BOOST_CHECK(t.readChecksum(i) == 0);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(nocheck_iblt_can_serde_properly)
+{
+    uint64_t version = 2;
+    uint8_t nChecksumBits = 11;
+    uint32_t salt = 5;
+    std::set<std::pair<uint64_t, std::vector<uint8_t> > > expected;
+    CIbltNoCheck t1(20, salt, version, nChecksumBits);
+    CDataStream ss(SER_DISK, 0);
+
+    for (int i = 0; i < 20; i++)
+    {
+        t1.insert(i, PseudoRandomValue(i * 2));
+        expected.insert(std::make_pair(i, PseudoRandomValue(i * 2)));
+    }
+
+    ss << t1;
+    CIbltNoCheck t2;
+    ss >> t2;
+
+    std::set<std::pair<uint64_t, std::vector<uint8_t> > > entries;
+    bool fAllFound = t2.listEntries(entries, entries);
+    BOOST_CHECK(fAllFound && entries == expected);
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This PR is actually a summary of the prototype I developed for variable checksums in `CIblt`. Every cell in `CIblt` is an instance of `HashTableEntry`, which itself includes a 32 bit checksum used for detecting *impure* cells, i.e. cells that contain bogus key / value data. Note that the code was based on other partially completed PRs that were in-flight at the time, which have been subsequently merged to dev. Therefore, this code would require a major rebase before being merged to dev. 

The reason I have decided to post this in its current state is that I have some serious concerns about the complexity of the change, particularly if we wish to maintain backward compatibility with currently deployed clients. To start, almost every method in `CIblt` must be reworked to account for the change. The changes to `HashTableEntry` specifically are rather substantial because there is no way to represent "partial" bytes in a single cell, therefore the hash table data must be moved into the `CIblt` class and delegated to `HashTableEntry` when modifications are required. Moreover, because the signatures of many methods changed and new data members are required, it would be very messy to support legacy and variable checksum IBLTs in the same class. Therefore, it was necessary to create separate classes `HashTableEntryNoCheck` and `CIbltNoCheck` alongside the existing, legacy, implementations. Unfortunately, the legacy client concerns also bleed into the `CGrapheneSet` implementation, which needs to carry around pointers to both type of IBLTs.

With the my concerns having been said, the patch works well; I ran it on mainnet for several days without any problems. So if the reduction in size is worth the time, then I regard this change as doable. Accordingly, I'd like to briefly discuss what kind of improvement in block size we can expect to achieve given this change. I have performed some [analysis](https://github.com/bissias/graphene-experiments/blob/master/jupyter/min_checksum_IBLT.ipynb) to determine what is a safe quantity of bits to use for the checksum. It turns out that this depends on both the number of cells in the IBLT and the number of transactions in the receiver's mempool, but mostly the number of cells. The general trend is that more IBLT cells require a larger number of checksum bits. Therefore, a variable checksum size has diminishing returns in space savings as the number of cells in the IBLT increases.

In separate analysis, I have been collecting data on the sizes of Graphene blocks and the IBLTs within them. During a span of more than 15K blocks, I noticed that IBLT size tends to decrease relative to the block size as the block size increases. Therefore I believe that we can expect larger blocks will require slightly larger IBLTs, but that those IBLTs will constitute a decreasing fraction of the total block size. The block with the most transactions had an IBLT with 28 cells, which made up about 5% of the total size. The block with the largest size had an IBLT with only 16 cells, comprising 0.1% of its size. Let's say conservatively that as block sizes increase, IBLT size will be as much as 10% of the total size. An IBLT with 28 cells already requires about 14 bits for the checksum. So we can only hope to save approximately 60% of the IBLT space by reducing the checksum, which would amount to just 6% savings in the block size overall.

Perhaps it's obvious that I'm leaning toward abandoning the idea of a variable IBLT checksum. But I do want to emphasize that I'm open to other opinions and very happy to discuss further.