### PR TITLE
Known dbs to dag

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -71,6 +71,7 @@ BITCOIN_TESTS =\
   test/checkblock_tests.cpp \
   test/checkdatasig_tests.cpp \
   test/Checkpoints_tests.cpp \
+  test/bobtail_tests.cpp \
   test/bswap_tests.cpp \
   test/cashaddr_tests.cpp \
   test/cashaddrenc_tests.cpp \

--- a/src/blockrelay/netdeltablocks.h
+++ b/src/blockrelay/netdeltablocks.h
@@ -1,6 +1,7 @@
 #ifndef BITCOIN_BLOCKRELAY_NETDELTABLOCKS_H
 #define BITCOIN_BLOCKRELAY_NETDELTABLOCKS_H
 
+#include "bobtail/subblock.h"
 #include "serialize.h"
 #include "deltablocks.h"
 #include "graphene.h"
@@ -16,8 +17,8 @@ public:
 /*! Graphene based network representation of a delta block. */
 class CNetDeltaBlock {
     friend class CNetDeltaRequestMissing;
-    friend bool sendFullDeltaBlock(ConstCDeltaBlockRef db, CNode* pto);
-    friend bool sendDeltaBlock(ConstCDeltaBlockRef db, CNode* pto, std::set<uint64_t> requestedCheapHashes);
+    friend bool sendFullDeltaBlock(const CSubBlockRef db, CNode* pto);
+    friend bool sendDeltaBlock(const CSubBlockRef db, CNode* pto, std::set<uint64_t> requestedCheapHashes);
 private:
     CBlockHeader header;
     CGrapheneSet *delta_gset;
@@ -43,7 +44,7 @@ public:
     }
 
     // FIXME: sip hashing
-    CNetDeltaBlock(ConstCDeltaBlockRef &dbref,
+    CNetDeltaBlock(const CSubBlockRef &dbref,
                    uint64_t nReceiverMemPoolTx);
 
     // Empty constructor used for deserialization
@@ -52,14 +53,10 @@ public:
     /*! Reconstruct delta block from wire format. Returns false for an
       unrecoverable error, true when it is worth trying again with more
       info. */
-    bool reconstruct(CDeltaBlockRef& dbr, CNetDeltaRequestMissing** ppmissing_tx = nullptr);
+    bool reconstruct(CSubBlockRef& dbr, CNetDeltaRequestMissing** ppmissing_tx = nullptr);
 
     /*! Deal with an incoming network message of type DELTABLOCK */
     static bool HandleMessage(CDataStream &vRecv, CNode *pfrom);
-
-    /*! Call this when a new delta block arrived, weak or strong. This
-     *  will process it and send it around to everyone. */
-    static void processNew(CDeltaBlockRef dbr, CNode *pfrom);
 };
 
 

--- a/src/bobtail/subblock.cpp
+++ b/src/bobtail/subblock.cpp
@@ -58,3 +58,20 @@ std::set<uint256> CSubBlock::GetAncestorHashes() const
     }
     return ancestors;
 }
+
+std::vector<uint256> CSubBlock::GetTxHashes() const
+{
+    std::vector<uint256> hashes;
+    for (const auto &txref : vtx)
+    {
+        hashes.push_back(txref->GetHash());
+    }
+
+    return hashes;
+}
+
+const CSubBlockRef CSubBlock::SubBlockByHash(const uint256& hash)
+{
+    //TODO: ADD DAG LOOKUP LOGIC HERE!!!
+    return nullptr;
+}

--- a/src/bobtail/subblock.h
+++ b/src/bobtail/subblock.h
@@ -7,10 +7,14 @@
 
 #include "primitives/block.h"
 
+class CSubBlock;
+typedef std::shared_ptr<CSubBlock> CSubBlockRef;
+
 class CSubBlock : public CBlockHeader
 {
 public:
     std::vector<CTransactionRef> vtx;
+    bool fXVal;
 
     CSubBlock() { SetNull(); }
 
@@ -38,6 +42,10 @@ public:
     std::string ToString() const;
 
     std::set<uint256> GetAncestorHashes() const;
+
+    std::vector<uint256> GetTxHashes() const;
+
+    static const CSubBlockRef SubBlockByHash(const uint256& hash);
 };
 
 

--- a/src/deltablocks.h
+++ b/src/deltablocks.h
@@ -130,6 +130,10 @@ public:
     //! Reset internal data; mostly for unit testing
     static void resetAll();
 
+    /*! Call this when a new delta block arrived, weak or strong. This
+     *  will process it and send it around to everyone. */
+    static void processNew(CDeltaBlockRef dbr);
+
     //! Test outpoint for whether it is spent in the delta block already
     bool spendsOutput(const COutPoint &out) const;
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -150,7 +150,8 @@ UniValue generateBlocks(boost::shared_ptr<CReserveScript> coinbaseScript,
             continue;
 
         LOG(WB, "PROCESS NEW WEAK\n");
-        CNetDeltaBlock::processNew(pblock, nullptr);
+        CDeltaBlock::processNew(pblock);
+        //TODO: ACTUALLY CALL sendDeltaBlock here
         CDeltaBlock::tryRegister(pblock);
 
         // Now check if Bobtail PoW is also satisfied

--- a/src/test/bobtail_tests.cpp
+++ b/src/test/bobtail_tests.cpp
@@ -1,0 +1,20 @@
+#include "bobtail/dag.h"
+#include "bobtail/subblock.h"
+#include "test/test_bitcoin.h"
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(bobtail_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(test_dag_temporal_sort)
+{
+    CDagForrest forest;
+    CSubBlock subblock1;
+    CSubBlock subblock2;
+    forest.Insert(subblock1);
+    forest.Insert(subblock2);
+    forest.TemporalSort();
+
+    BOOST_CHECK(forest.IsTemporallySorted());
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -742,7 +742,8 @@ void static BitcoinMiner(const CChainParams &chainparams)
                         bool is_strong = UintToArith256(hash) <= hashStrongTarget;
                         if (pblocktemplate->delta_block != nullptr)
                         {
-                            CNetDeltaBlock::processNew(pblocktemplate->delta_block, nullptr);
+                            CDeltaBlock::processNew(pblocktemplate->delta_block);
+                            //TODO: ACTUALLY CALL sendDeltaBlock here
                         }
                         if (is_strong)
                         {


### PR DESCRIPTION
This is a first step toward removing CDeltaBlock. In this PR, I remove CDeltaBlock from netdeltablocks.cpp and replace it with CSubBlock. The code compiles, but breaks the bobtail.py qa test (in fact, subblock/deltablock propagation is currently totally broken).